### PR TITLE
Allow RichText features on Footnote text to be defined in settings

### DIFF
--- a/wagtail_footnotes/models.py
+++ b/wagtail_footnotes/models.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db import models
 from modelcluster.fields import ParentalKey
 from wagtail.admin.edit_handlers import FieldPanel, InlinePanel
@@ -21,6 +22,12 @@ class Footnote(models.Model):
         help_text="The ID of the footnote is shown in the rich text editor for "
         "reference.",
     )
-    text = RichTextField(features=["bold", "italic", "link"])
+    text = RichTextField(
+        features=getattr(
+            settings, 
+            'WAGTAIL_FOOTNOTES_TEXT_FEATURES', 
+            ["bold", "italic", "link"]
+        )
+    )
 
     panels = [FieldPanel("text"), FieldPanel("uuid", widget=ReadonlyUUIDInput)]


### PR DESCRIPTION
This is to allow the RichText features on the Footnote model text field to be given a custom definition in the project settings.

It checks for a setting 'WAGTAIL_FOOTNOTES_TEXT_FEATURES' and if not present defaults to the existing options as a default, i.e. ["bold", "italic", "link"].

For example, I am using this for an academic website where we need a CITE tag to be available for footnotes (the CITE tag itself is added as an InlineStyleFeature elsewhere on the website project).