### PR TITLE
Only attempt to add footnotes if the context's 'page' is a Page object

### DIFF
--- a/wagtail_footnotes/blocks.py
+++ b/wagtail_footnotes/blocks.py
@@ -30,7 +30,7 @@ class RichTextBlockWithFootnotes(RichTextBlock):
         else:
             new_context = self.get_context(value, parent_context=dict(context))
 
-        if "page" not in new_context or not isinstance(new_context["page"], Page):
+        if not isinstance(new_context.get("page"), Page):
             return html
 
         page = new_context["page"]

--- a/wagtail_footnotes/blocks.py
+++ b/wagtail_footnotes/blocks.py
@@ -3,6 +3,7 @@ import re
 from django.core.exceptions import ValidationError
 from django.utils.safestring import mark_safe
 from wagtail.core.blocks import RichTextBlock
+from wagtail.core.models import Page
 
 FIND_FOOTNOTE_TAG = re.compile(r'<footnote id="(.*?)">.*?</footnote>')
 
@@ -29,7 +30,7 @@ class RichTextBlockWithFootnotes(RichTextBlock):
         else:
             new_context = self.get_context(value, parent_context=dict(context))
 
-        if "page" not in new_context:
+        if "page" not in new_context or not isinstance(new_context["page"], Page):
             return html
 
         page = new_context["page"]


### PR DESCRIPTION
The current check in `replace_footnote_tags` looks to see if `page` exists in the new context, but doesn't check whether it's actually a `Page`-based object. This change ensures that the method has a `Page` to work with before proceeding.