### PR TITLE
Cast ``Footnote.uuid`` to string so previews work

### DIFF
--- a/wagtail_footnotes/blocks.py
+++ b/wagtail_footnotes/blocks.py
@@ -36,7 +36,7 @@ class RichTextBlockWithFootnotes(RichTextBlock):
         page = new_context["page"]
         if not hasattr(page, "footnotes_list"):
             page.footnotes_list = []
-        self.footnotes = {footnote.uuid: footnote for footnote in page.footnotes.all()}
+        self.footnotes = {str(footnote.uuid): footnote for footnote in page.footnotes.all()}
 
         def replace_tag(match):
             try:


### PR DESCRIPTION
The keys in ``self.footnotes`` need to be strings in order for lookups to work, but before the ``Footnote`` is saved to the db, it is of type ``UUID``.

Refs #23