### PR TITLE
Drop Django constraint and let Wagtail dictate it

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ name = wagtail-footnotes
 author = Cameron Lamb
 author_email = cameron.lamb@torchbox.com
 description = Add footnotes to rich text in your Wagtail pages
-version = 0.8.0
+version = 0.8.1
 url = https://github.com/torchbox/wagtail-footnotes
 keywords =
   wagtail
@@ -21,5 +21,4 @@ setup_requires =
 include_package_data = true
 packages = find:
 install_requires =
-    Django>=3.2, <4.0
     wagtail>=2.15, <4.0


### PR DESCRIPTION
Raised in https://github.com/torchbox/wagtail-footnotes/pull/29#issuecomment-1164984821

Opting to let Wagtail define what version of django is required

cc @jsma 