### PR TITLE
Fix: related name is `footnotes` not `footnotes_list`

### DIFF
--- a/wagtail_footnotes/blocks.py
+++ b/wagtail_footnotes/blocks.py
@@ -44,7 +44,7 @@ class RichTextBlockWithFootnotes(RichTextBlock):
             return html
 
         page = new_context["page"]
-        if not hasattr(page, "footnotes_list"):
+        if not hasattr(page, "footnotes"):
             page.footnotes_list = []
         self.footnotes = {str(footnote.uuid): footnote for footnote in page.footnotes.all()}
 


### PR DESCRIPTION
Related to #34 - noticing the following:

https://github.com/torchbox/wagtail-footnotes/blob/21a3ad547467c0d515fa102d430892b81b99187a/wagtail_footnotes/models.py#L21-L28

It would of course be very nice if there were tests to verify my claim.

I can report back if this fix works (am currently using just `RichTextField` and not the block)