### PR TITLE
Adds apps file to specifcy auto field

### DIFF
--- a/wagtail_footnotes/apps.py
+++ b/wagtail_footnotes/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class WagtailFootnotesConfig(AppConfig):
+    default_auto_field = "django.db.models.AutoField"
+    name = "wagtail_footnotes"


### PR DESCRIPTION
We're getting a problem locally. In our project we have:
`DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"`

Which, because this app doesn't specify its auto field (as it has no apps.py file), it makes a migration:
```
(shiftingpower) Olivers-MacBook-Pro:shiftingpower oli$ ./manage.py makemigrations
Migrations for 'wagtail_footnotes':
  /Users/oli/.virtualenvs/shiftingpower/lib/python3.10/site-packages/wagtail_footnotes/migrations/0003_alter_footnote_id.py
    - Alter field id on footnote 
 ```

```
# Generated by Django 3.2.14 on 2022-07-25 13:48

from django.db import migrations, models


class Migration(migrations.Migration):

    dependencies = [
        ('wagtail_footnotes', '0002_alter_footnote_unique_together'),
    ]

    operations = [
        migrations.AlterField(
            model_name='footnote',
            name='id',
            field=models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID'),
        ),
    ]
```

Adding this file stops this migration getting made