### PR TITLE
[dependencies] Allow use with Wagtail 5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Wagtail Footnotes Changelog
 
+## 0.9.2
+
+- Add support for Wagtail 5.x
+
 ## 0.9.0
 
 - Add support for Wagtail 4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ name = wagtail-footnotes
 author = Cameron Lamb
 author_email = cameron.lamb@torchbox.com
 description = Add footnotes to rich text in your Wagtail pages
-version = 0.9.0
+version = 0.9.2
 url = https://github.com/torchbox/wagtail-footnotes
 keywords =
   wagtail
@@ -21,4 +21,4 @@ setup_requires =
 include_package_data = true
 packages = find:
 install_requires =
-    wagtail>=2.15, <5.0
+    wagtail>=2.15, <6.0


### PR DESCRIPTION
I just did a quick test on the project I'm currently working on, and it seems that nothing prevents `wagtail-footnotes` from doing its job on a Wagtail 5.0 instance, so this should be rather safe to merge? :slightly_smiling_face: 

Whether it's in the Wagtail Admin or the frontend, everything seems to be working correctly.  
(I would attach screenshots if I could, but it seems to be disabled on this GitHub repo?)

