### PR TITLE
Wagtail 6.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,17 +8,17 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 env:
-  PYTHON_LATEST: "3.11"
+  PYTHON_LATEST: "3.12"
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{env.PYTHON_LATEST}}
           cache: "pip"
@@ -32,7 +32,7 @@ jobs:
       - name: 🏗️ Build
         run: python -Im flit build
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./dist
 
@@ -47,7 +47,7 @@ jobs:
       # Mandatory for trusted publishing
       id-token: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
 
       - name: 🚀 Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,13 +57,13 @@ jobs:
       - name: 🏗️ Build wheel
         run: python -Im flit build --format wheel
 
-      - name: 🧪 Run tox targets for Python ${{ matrix.python-version }}
+      - name: 🧪 Run tox targets for Python ${{ matrix.python }}
         run: tox --installpkg ./dist/*.whl
 
       - name: ⬆️ Upload coverage data
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-data
+          name: coverage-data-${{ matrix.python }}
           path: .coverage.*
           if-no-files-found: ignore
           retention-days: 1
@@ -85,7 +85,8 @@ jobs:
       - name: ⬇️ Download coverage data
         uses: actions/download-artifact@v4
         with:
-          name: coverage-data
+          pattern: coverage-data-*
+          merge-multiple: true
 
       - name: ＋  Combine coverage
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ env:
   TOX_TESTENV_PASSENV: FORCE_COLOR
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
   PIP_NO_PYTHON_VERSION_WARNING: "1"
-  PYTHON_LATEST: "3.11"
+  PYTHON_LATEST: "3.12"
 
 
 jobs:
@@ -28,10 +28,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{env.PYTHON_LATEST}}
       - uses: pre-commit/action@v3.0.0
@@ -44,9 +44,9 @@ jobs:
         python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 🐍 Setup Python ${{ matrix.python }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - name: 📦 Install dependencies
@@ -61,7 +61,7 @@ jobs:
         run: tox --installpkg ./dist/*.whl
 
       - name: ⬆️ Upload coverage data
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-data
           path: .coverage.*
@@ -72,10 +72,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: tests
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           # Use latest Python, so it understands all syntax.
           python-version: ${{env.PYTHON_LATEST}}
@@ -83,7 +83,7 @@ jobs:
       - run: python -Im pip install --upgrade "coverage[toml]>=7.2,<8.0"
 
       - name: ⬇️ Download coverage data
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: coverage-data
 
@@ -95,7 +95,7 @@ jobs:
           echo "## Coverage summary" >> $GITHUB_STEP_SUMMARY
           python -Im coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
       - name: 📈 Upload HTML report if check failed.
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: html-report
           path: htmlcov

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ ci:
   autofix_prs: false
 
 default_language_version:
-  python: python3.11
+  python: python3.12
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ## Unreleased
 
-- Add support for Wagtail 5.2
-- Add Wagtail 5.2 and Python 3.12 in test matrices @katdom13
-- Add support for Wagtail 6.0 by @katdom13
+- Add support for Wagtail 6.0 @katdom13
 - Add support for Django 5.0 by @katdom13
+- Add compatibility tests for Wagtail 6.0 and Python 3.12 @katdom13
 
 ## 0.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 ## Unreleased
 
 - Drop support for Wagtail < 5.2 @katdom13
-- Add support for Wagtail 6.0 @katdom13
+- Drop support for Django < 4.2 @katdom13
+- Add support for Wagtail 6 @katdom13
 - Add support for Django 5.0 by @katdom13
-- Add compatibility tests for Wagtail 6.0 and Python 3.12 @katdom13
+- Add compatibility tests for Wagtail 6 and Python 3.12 @katdom13
 
 ## 0.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Add support for Wagtail 5.2
 - Add Wagtail 5.2 and Python 3.12 in test matrices @katdom13
+- Add support for Wagtail 6.0 by @katdom13
+- Add support for Django 5.0 by @katdom13
 
 ## 0.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Drop support for Wagtail < 5.2 @katdom13
 - Add support for Wagtail 6.0 @katdom13
 - Add support for Django 5.0 by @katdom13
 - Add compatibility tests for Wagtail 6.0 and Python 3.12 @katdom13

--- a/README.md
+++ b/README.md
@@ -174,11 +174,11 @@ tox
 To run tests for a specific environment:
 
 ```shell
-tox -e python3.11-django4.2-wagtail5.2
+tox -e python3.12-django5.0-wagtail6.0
 ```
 
 To run a single test method in a specific environment:
 
 ```shell
-tox -e python3.11-django4.2-wagtail5.2 -- tests.test.test_blocks.TestBlocks.test_block_with_features
+tox -e python3.12-django5.0-wagtail6.0 -- tests.test.test_blocks.TestBlocks.test_block_with_features
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,14 +23,13 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Framework :: Django",
-    "Framework :: Django :: 3",
     "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4",
-    "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.0",
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 4",
     "Framework :: Wagtail :: 5",
+    "Framework :: Wagtail :: 6",
 ]
 
 dynamic = ["version"]  # will read __version__ from wagtail_footnotes/__init__.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ testing = [
     "tox>=4.6.4,<5",
     "ruff==0.3.7",
     "coverage[toml]>=7.2,<8.0",
+    "wagtail-modeladmin>=2.0.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 dynamic = ["version"]  # will read __version__ from wagtail_footnotes/__init__.py
 requires-python = ">=3.8"
 dependencies = [
-    "Wagtail>=4.1",
+    "Wagtail>=5.2",
     "Django>=3.2",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Wagtail",
@@ -35,7 +34,7 @@ dynamic = ["version"]  # will read __version__ from wagtail_footnotes/__init__.p
 requires-python = ">=3.8"
 dependencies = [
     "Wagtail>=5.2",
-    "Django>=3.2",
+    "Django>=4.2",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ classifiers = [
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 4",
     "Framework :: Wagtail :: 5",
     "Framework :: Wagtail :: 6",
 ]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -10,8 +10,6 @@ https://docs.djangoproject.com/en/stable/ref/settings/
 
 import os
 
-from wagtail import VERSION as WAGTAIL_VERSION
-
 
 # Build paths inside the project like this: os.path.join(PROJECT_DIR, ...)
 PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -40,7 +38,7 @@ INSTALLED_APPS = [
     "wagtail.images",
     "wagtail.search",
     "wagtail.admin",
-    "wagtail_modeladmin" if WAGTAIL_VERSION >= (5, 1) else "wagtail.contrib.modeladmin",
+    "wagtail_modeladmin",
     "wagtail.sites",
     "wagtail",
     "taggit",

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -10,6 +10,8 @@ https://docs.djangoproject.com/en/stable/ref/settings/
 
 import os
 
+from wagtail import VERSION as WAGTAIL_VERSION
+
 
 # Build paths inside the project like this: os.path.join(PROJECT_DIR, ...)
 PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -38,6 +40,7 @@ INSTALLED_APPS = [
     "wagtail.images",
     "wagtail.search",
     "wagtail.admin",
+    "wagtail_modeladmin" if WAGTAIL_VERSION >= (5, 1) else "wagtail.contrib.modeladmin",
     "wagtail.sites",
     "wagtail",
     "taggit",

--- a/tests/test/test_widgets.py
+++ b/tests/test/test_widgets.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.test import TestCase
+from wagtail import VERSION as WAGTAIL_VERSION
 
 from wagtail_footnotes.widgets import ReadonlyUUIDInput
 
@@ -8,11 +9,18 @@ class TestWidgets(TestCase):
     def test_read_only_uuid_input(self):
         form = forms.Form()
         form.fields["uuid"] = forms.CharField(widget=ReadonlyUUIDInput)
-        self.assertInHTML(
-            '<input type="hidden" name="uuid" id="id_uuid">',
-            form.as_p(),
-        )
-        self.assertInHTML(
-            '<script>setUUID("id_uuid");</script>',
-            form.as_p(),
-        )
+
+        if WAGTAIL_VERSION >= (6, 0):
+            self.assertInHTML(
+                '<input type="hidden" name="uuid" id="id_uuid" data-controller="read-only-uuid">',
+                form.as_p(),
+            )
+        else:
+            self.assertInHTML(
+                '<input type="hidden" name="uuid" id="id_uuid">',
+                form.as_p(),
+            )
+            self.assertInHTML(
+                '<script>setUUID("id_uuid");</script>',
+                form.as_p(),
+            )

--- a/tox.ini
+++ b/tox.ini
@@ -36,9 +36,9 @@ deps =
     wagtail6.0: wagtail>=6.0,<6.1
 
 
+extras = testing
 install_command = python -Im pip install -U {opts} {packages}
 commands =
-    python -Im pip install -e '.[testing]' -U
     python -Im coverage run testmanage.py test --deprecation all {posargs: -v 2}
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,9 @@
 min_version = 4.0
 
 envlist =
-    python{3.8,3.9,3.10,3.11}-django{3.2}-wagtail{4.1,5.2}
-    python3.12-django3.2-wagtail5.2
-    python{3.8,3.9,3.10,3.11}-django{4.2}-wagtail{5.2,6.0}
-    python{3.10,3.11,3.12}-django{5.0}-wagtail{5.2,6.0}
+    python{3.8,3.9,3.10,3.11,3.12}-django3.2-wagtail5.2
+    python{3.8,3.9,3.10,3.11}-django4.2-wagtail{5.2,6.0}
+    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.0}
 
 [gh-actions]
 python =
@@ -31,7 +30,6 @@ deps =
     django4.2: Django>=4.2,<4.3
     django5.0: Django>=5.0,<5.1
 
-    wagtail4.1: wagtail>=4.1,<4.2
     wagtail5.2: wagtail>=5.2,<5.3
     wagtail6.0: wagtail>=6.0,<6.1
 

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,7 @@ deps =
 
 install_command = python -Im pip install -U {opts} {packages}
 commands =
+    python -Im pip install -e '.[testing]' -U
     python -Im coverage run testmanage.py test --deprecation all {posargs: -v 2}
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,10 @@
 min_version = 4.0
 
 envlist =
-    python{3.8,3.9,3.10}-django{3.2}-wagtail{4.1,5.1,5.2}
-    python{3.9,3.10,3.11}-django{4.1}-wagtail{4.1,5.1,5.2}
-    python{3.10,3.11}-django{4.2}-wagtail{5.1,5.2}
-    python3.12-django4.2-wagtail5.2
+    python{3.8,3.9,3.10,3.11}-django{3.2}-wagtail{4.1,5.2}
+    python3.12-django3.2-wagtail5.2
+    python{3.8,3.9,3.10,3.11}-django{4.2}-wagtail{5.2,6.0}
+    python{3.10,3.11,3.12}-django{5.0}-wagtail{5.2,6.0}
 
 [gh-actions]
 python =
@@ -28,12 +28,12 @@ deps =
     coverage[toml]>=7.2,<8.0
 
     django3.2: Django>=3.2,<4.0
-    django4.1: Django>=4.1,<4.2
     django4.2: Django>=4.2,<4.3
+    django5.0: Django>=5.0,<5.1
 
     wagtail4.1: wagtail>=4.1,<4.2
-    wagtail5.1: wagtail>=5.1,<5.2
     wagtail5.2: wagtail>=5.2,<5.3
+    wagtail6.0: wagtail>=6.0,<6.1
 
 
 install_command = python -Im pip install -U {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,8 @@
 min_version = 4.0
 
 envlist =
-    python{3.8,3.9,3.10,3.11,3.12}-django3.2-wagtail5.2
-    python{3.8,3.9,3.10,3.11}-django4.2-wagtail{5.2,6.0}
-    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.0}
+    python{38,39,310,311}-dj{42}-wt{52,60,61}
+    python{312}-dj{50}-wt{52,60,61}
 
 [gh-actions]
 python =
@@ -26,12 +25,12 @@ pass_env =
 deps =
     coverage[toml]>=7.2,<8.0
 
-    django3.2: Django>=3.2,<4.0
     django4.2: Django>=4.2,<4.3
     django5.0: Django>=5.0,<5.1
 
     wagtail5.2: wagtail>=5.2,<5.3
     wagtail6.0: wagtail>=6.0,<6.1
+    wagtail6.1: wagtail>=6.1,<6.2
 
 
 extras = testing

--- a/wagtail_footnotes/blocks.py
+++ b/wagtail_footnotes/blocks.py
@@ -2,7 +2,6 @@ import re
 
 from django.core.exceptions import ValidationError
 from django.utils.safestring import mark_safe
-from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.blocks import RichTextBlock
 from wagtail.models import Page
 
@@ -54,9 +53,7 @@ class RichTextBlockWithFootnotes(RichTextBlock):
         return mark_safe(FIND_FOOTNOTE_TAG.sub(replace_tag, html))  # noqa: S308
 
     def render(self, value, context=None):
-        kwargs = {"value": value} if WAGTAIL_VERSION >= (5, 2) else {}
-
-        if not self.get_template(context=context, **kwargs):
+        if not self.get_template(value=value, context=context):
             return self.render_basic(value, context=context)
 
         html = super().render(value, context=context)

--- a/wagtail_footnotes/static/footnotes/js/read-only-uuid-controller.js
+++ b/wagtail_footnotes/static/footnotes/js/read-only-uuid-controller.js
@@ -1,0 +1,9 @@
+// wagtail_footnotes/static/footnotes/js/read-only-uuid-controller.js
+
+class CustomEditorController extends window.StimulusModule.Controller {
+    connect() {
+        setUUID(this.element.id);
+    }
+}
+
+window.wagtail.app.register('read-only-uuid', CustomEditorController);

--- a/wagtail_footnotes/static/footnotes/js/read-only-uuid-controller.js
+++ b/wagtail_footnotes/static/footnotes/js/read-only-uuid-controller.js
@@ -1,9 +1,0 @@
-// wagtail_footnotes/static/footnotes/js/read-only-uuid-controller.js
-
-class CustomEditorController extends window.StimulusModule.Controller {
-    connect() {
-        setUUID(this.element.id);
-    }
-}
-
-window.wagtail.app.register('read-only-uuid', CustomEditorController);

--- a/wagtail_footnotes/static/footnotes/js/read-only-uuid-controller.js
+++ b/wagtail_footnotes/static/footnotes/js/read-only-uuid-controller.js
@@ -1,0 +1,9 @@
+// myapp/static/js/read-only-uuid-controller.js
+
+class CustomEditorController extends window.StimulusModule.Controller {
+    connect() {
+        setUUID(this.element.id);
+    }
+}
+
+window.wagtail.app.register('read-only-uuid', CustomEditorController);

--- a/wagtail_footnotes/widgets.py
+++ b/wagtail_footnotes/widgets.py
@@ -1,20 +1,66 @@
 from django.forms import HiddenInput
-from wagtail.utils.widgets import WidgetWithScript
+from wagtail import VERSION as WAGTAIL_VERSION
 
 
-class ReadonlyUUIDInput(WidgetWithScript, HiddenInput):
-    """
-    This isn't really read-only. It's a hidden input with an an adjacent div
-    showing the current value; that way we can set the value in JavaScript, but
-    the user can't easily change it.
-    """
+if WAGTAIL_VERSION >= (6, 0):
+    from django.forms import Media
+    from django.utils.safestring import mark_safe
 
-    def render_html(self, name, value, attrs):
-        """Render the HTML (non-JS) portion of the field markup"""
-        hidden = super(WidgetWithScript, self).render(name, value, attrs)
-        display_value = value[:6] if value is not None else value
-        shown = f'<div id="{attrs["id"]}_display-value" style="padding-top: 1.2em;">{display_value}</div>'
-        return shown + hidden
+    class ReadonlyUUIDInput(HiddenInput):
+        """
+        This isn't really read-only. It's a hidden input with an an adjacent div
+        showing the current value; that way we can set the value in JavaScript, but
+        the user can't easily change it.
+        """
 
-    def render_js_init(self, id_, name, value):
-        return f'setUUID("{id_}");'
+        def render_html(self, name, value, attrs):
+            """Render the HTML (non-JS) portion of the field markup"""
+            hidden = super().render(name, value, attrs)
+            display_value = value[:6] if value is not None else value
+            shown = f'<div id="{attrs["id"]}_display-value" style="padding-top: 1.2em;">{display_value}</div>'
+            return mark_safe(shown + hidden)  # noqa: S308
+
+        def render(self, name, value, attrs=None, renderer=None):
+            # Ensure 'id' is present in attrs
+            try:
+                attrs["id"]
+            except (KeyError, TypeError):
+                raise TypeError(  # noqa: B904
+                    "ReadonlyUUIDInput cannot be rendered without an 'id' attribute"
+                )
+
+            # Render the HTML portion
+            widget_html = self.render_html(name, value, attrs)
+
+            # Combine HTML and JavaScript, and mark as safe
+            out = f"{widget_html}<script></script>"
+            return mark_safe(out)  # noqa: S308
+
+        def build_attrs(self, *args, **kwargs):
+            attrs = super().build_attrs(*args, **kwargs)
+            attrs["data-controller"] = "read-only-uuid"
+            return attrs
+
+        @property
+        def media(self):
+            return Media(js=["js/custom-editor-controller.js"])
+
+else:
+    from wagtail.utils.widgets import WidgetWithScript
+
+    class ReadonlyUUIDInput(WidgetWithScript, HiddenInput):
+        """
+        This isn't really read-only. It's a hidden input with an an adjacent div
+        showing the current value; that way we can set the value in JavaScript, but
+        the user can't easily change it.
+        """
+
+        def render_html(self, name, value, attrs):
+            """Render the HTML (non-JS) portion of the field markup"""
+            hidden = super(WidgetWithScript, self).render(name, value, attrs)
+            display_value = value[:6] if value is not None else value
+            shown = f'<div id="{attrs["id"]}_display-value" style="padding-top: 1.2em;">{display_value}</div>'
+            return shown + hidden
+
+        def render_js_init(self, id_, name, value):
+            return f'setUUID("{id_}");'


### PR DESCRIPTION
# Notes

- No significant changes related to Wagtail 6.1
- Drop support for Django < 4.2 as those have reached EOL

# Wagtail 6.1 upgrade check list

## Code reviewing a consideration.
Use the tick box to indicate a consideration has been code reviewed as OK

### What’s new
  - [ ] [Universal listings continued](https://docs.wagtail.org/en/latest/releases/6.1.html#universal-listings-continued)
  - [ ] [Information-dense admin interface](https://docs.wagtail.org/en/latest/releases/6.1.html#information-dense-admin-interface)
  - [ ] [Custom per-page-type listings](https://docs.wagtail.org/en/latest/releases/6.1.html#custom-per-page-type-listings)
  - [ ] [Keyboard shortcuts overview](https://docs.wagtail.org/en/latest/releases/6.1.html#keyboard-shortcuts-overview)
  - [ ] [Better guidance for password-protected content](https://docs.wagtail.org/en/latest/releases/6.1.html#better-guidance-for-password-protected-content)
  - [ ] [Favicon images generation](https://docs.wagtail.org/en/latest/releases/6.1.html#favicon-images-generation)
  - [ ] [Cve-2024-32882: permission check bypass when editing a model with per-field restrictions through wagtail.contrib.settings or modelviewset](https://docs.wagtail.org/en/latest/releases/6.1.html#cve-2024-32882-permission-check-bypass-when-editing-a-model-with-per-field-restrictions-through-wagtail-contrib-settings-or-modelviewset)
  - [ ] [Other features](https://docs.wagtail.org/en/latest/releases/6.1.html#other-features)
  - [ ] [Bug fixes](https://docs.wagtail.org/en/latest/releases/6.1.html#bug-fixes)
  - [ ] [Documentation](https://docs.wagtail.org/en/latest/releases/6.1.html#documentation)
  - [ ] [Maintenance](https://docs.wagtail.org/en/latest/releases/6.1.html#maintenance)
### Changes affecting wagtail customizations
  - [ ] [Changes to submissionslistview class](https://docs.wagtail.org/en/latest/releases/6.1.html#changes-to-submissionslistview-class)
  - [ ] [Register_user_listing_buttons hook signature changed](https://docs.wagtail.org/en/latest/releases/6.1.html#register-user-listing-buttons-hook-signature-changed)
  - [ ] [Password_required_template has changed to wagtail_password_required_template](https://docs.wagtail.org/en/latest/releases/6.1.html#password-required-template-has-changed-to-wagtail-password-required-template)
  - [ ] [Document_password_required_template has changed to wagtaildocs_password_required_template](https://docs.wagtail.org/en/latest/releases/6.1.html#document-password-required-template-has-changed-to-wagtaildocs-password-required-template)
### Changes to undocumented internals
  - [ ] [Deprecation of user_listing_buttons template tag](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-user-listing-buttons-template-tag)
  - [ ] [Deprecation of wagtailusers_groups:users url pattern](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-wagtailusers-groups-users-url-pattern)
  - [ ] [Deprecation of window.chooserurls within draftail choosers](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-window-chooserurls-within-draftail-choosers)
  - [ ] [Deprecation of window.initblockwidget to initialize a streamfield block](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-window-initblockwidget-to-initialize-a-streamfield-block)
  - [ ] [Old](https://docs.wagtail.org/en/latest/releases/6.1.html#id1)
  - [ ] [New](https://docs.wagtail.org/en/latest/releases/6.1.html#id2)
  - [ ] [Removal of jquery from base client-side widget and boundwidget classes](https://docs.wagtail.org/en/latest/releases/6.1.html#removal-of-jquery-from-base-client-side-widget-and-boundwidget-classes)
  - [ ] [Window.urlify deprecated](https://docs.wagtail.org/en/latest/releases/6.1.html#window-urlify-deprecated)
  - [ ] [Window.xregexp polyfill removed](https://docs.wagtail.org/en/latest/releases/6.1.html#window-xregexp-polyfill-removed)