### PR TITLE
Allow custom footnote reference rendering

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - run: python -Im pip install --user ruff
+    - run: python -Im pip install --user ruff==0.5.0
 
     - name: Run ruff
       run: ruff check --output-format=github wagtail_footnotes

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -18,4 +18,4 @@ jobs:
     - run: python -Im pip install --user ruff
 
     - name: Run ruff
-      run: ruff --output-format=github wagtail_footnotes
+      run: ruff check --output-format=github wagtail_footnotes

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     - id: end-of-file-fixer
     - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.3.7'
+    rev: 'v0.5.0'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ WAGTAILADMIN_RICH_TEXT_EDITORS = {
   - Default: `["bold", "italic", "link"]`
   - Use this to update a list of Rich Text features allowed in the footnote text.
 
+- `WAGTAIL_FOOTNOTES_REFERENCE_TEMPLATE`
+  - Default: `"wagtail_footnotes/includes/footnote_reference.html"`
+  - Use this to set a template that renders footnote references. The template receives the footnote `index` in its context.
+
 ## 🌍 Internationalisation
 
 Wagtail Footnotes can be translated. Note that in a multi-lingual setup, the URL setup for footnotes

--- a/tests/templates/test/endnote_reference.html
+++ b/tests/templates/test/endnote_reference.html
@@ -1,0 +1,1 @@
+<a href="#endnote-{{ index }}" id="endnote-source-{{ index }}"><sup>{{ index }}</sup></a>

--- a/tests/test/test_blocks.py
+++ b/tests/test/test_blocks.py
@@ -1,6 +1,6 @@
 import json
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from wagtail import blocks
 from wagtail.fields import StreamBlock
 from wagtail.models import Page
@@ -104,7 +104,7 @@ class TestBlocks(TestCase):
         context = self.test_page_with_footnote.get_context(self.client.get("/"))
         out = rtb.render_basic(value, context=context)
         result = '<p>This is a paragraph with a footnote. <a href="#footnote-1" id="footnote-source-1"><sup>[1]</sup></a></p>'
-        self.assertEqual(out, result)
+        self.assertHTMLEqual(out, result)
 
     def test_block_replace_footnote_render(self):
         rtb = self.test_page_with_footnote.body.stream_block.child_blocks["paragraph"]
@@ -112,4 +112,21 @@ class TestBlocks(TestCase):
         context = self.test_page_with_footnote.get_context(self.client.get("/"))
         out = rtb.render(value, context=context)
         result = '<p>This is a paragraph with a footnote. <a href="#footnote-1" id="footnote-source-1"><sup>[1]</sup></a></p>'
-        self.assertEqual(out, result)
+        self.assertHTMLEqual(out, result)
+
+    def test_render_footnote_tag(self):
+        block = RichTextBlockWithFootnotes()
+        html = block.render_footnote_tag(2)
+        self.assertHTMLEqual(
+            html, '<a href="#footnote-2" id="footnote-source-2"><sup>[2]</sup></a>'
+        )
+
+    @override_settings(
+        WAGTAIL_FOOTNOTES_REFERENCE_TEMPLATE="test/endnote_reference.html"
+    )
+    def test_render_footnote_tag_new_template(self):
+        block = RichTextBlockWithFootnotes()
+        html = block.render_footnote_tag(2)
+        self.assertHTMLEqual(
+            html, '<a href="#endnote-2" id="endnote-source-2"><sup>2</sup></a>'
+        )

--- a/wagtail_footnotes/templates/wagtail_footnotes/includes/footnote_reference.html
+++ b/wagtail_footnotes/templates/wagtail_footnotes/includes/footnote_reference.html
@@ -1,0 +1,1 @@
+<a href="#footnote-{{ index }}" id="footnote-source-{{ index }}"><sup>[{{ index }}]</sup></a>


### PR DESCRIPTION
This change does two things to permit custom rendering of footnote references in the `RichTextBlockWithFootnotes` block:

1. Moves reference rendering from an inner function in the `replace_footnote_tags()` method to a separate `render_footnote_tag()` method on the `RichTextBlockWithFootnotes` block class. This provides an easy extension point for subclasses of `RichTextBlockWithFootnotes` to customize rendering that doesn't require duplication of a lot of other code.
2. The default implementation of `render_footnote_tag` renders using a Django template, optionally set with the `WAGTAIL_FOOTNOTES_REFERENCE_TEMPLATE` setting, allowing users to override rendering by providing a different template to that setting.

This is similar in spirit to @an-ant0ni0's proposal in #27, however we've chosen to move rendering out of Python f-strings altogether and into Django (or any other configured engine's) templates.

The motivation here, is we're adopting this package to replace our hand-crafted (😱) footnotes, and our existing style doesn't include `[]` brackets around the reference number. 

This will allow that kind of customization of reference rendering so users can render however their style specifies without having to subclass `RichTextBlockWithFootnotes` and include the full code of the `replace_footnote_tags()` with a single line f-string change. Instead, users will just have to provide a template.