### PR TITLE
Adjust tox testing for Wagtail 6.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Update tox testing to include Wagtail 6.3
+- Add tox testing for Django 5.1
+- Drop testing around python 3.8
+
 ## 0.13.0
 
 - Made the footnotes orderable (https://github.com/torchbox/wagtail-footnotes/pull/74) @willbarton

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.12",
     "Framework :: Django",
     "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.12",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.12",
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -26,13 +25,14 @@ classifiers = [
     "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.1",
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 5",
     "Framework :: Wagtail :: 6",
 ]
 
 dynamic = ["version"]  # will read __version__ from wagtail_footnotes/__init__.py
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "Wagtail>=5.2",
     "Django>=3.2",

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,11 @@
 min_version = 4.0
 
 envlist =
-    python{3.8,3.9,3.10,3.11}-django4.2-wagtail{5.2,6.1,6.2}
-    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.1,6.2}
+    python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.1,6.2,6.3}
+    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.1,6.2,6.3}
 
 [gh-actions]
 python =
-    3.8: python3.8
     3.9: python3.9
     3.10: python3.10
     3.11: python3.11
@@ -34,6 +33,7 @@ deps =
     wagtail5.2: wagtail>=5.2,<5.3
     wagtail6.1: wagtail>=6.1,<6.2
     wagtail6.2: wagtail>=6.2,<6.3
+    wagtail6.3: wagtail>=6.3,<6.4
 
 
 extras = testing

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,6 @@ deps =
     django5.1: Django>=5.1,<5.2
 
     wagtail5.2: wagtail>=5.2,<5.3
-    wagtail6.1: wagtail>=6.1,<6.2
     wagtail6.2: wagtail>=6.2,<6.3
     wagtail6.3: wagtail>=6.3,<6.4
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ min_version = 4.0
 envlist =
     python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.1,6.2,6.3}
     python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.1,6.2,6.3}
+    python{3.10,3.11,3.12}-django5.1-wagtail6.3
 
 [gh-actions]
 python =
@@ -29,6 +30,7 @@ set_env =
 deps =
     django4.2: Django>=4.2,<4.3
     django5.0: Django>=5.0,<5.1
+    django5.1: Django>=5.1,<5.2
 
     wagtail5.2: wagtail>=5.2,<5.3
     wagtail6.1: wagtail>=6.1,<6.2
@@ -50,12 +52,12 @@ commands =
 
 [testenv:interactive]
 description = An interactive environment for local testing purposes
-base_python = python3.11
+base_python = python3.12
 
 ; Note: the following are commented out for development convenience,
 ;       so as to test the interactive mode with a different Wagtail version
 ; deps =
-;     wagtail>=5.2,<6.0
+;     wagtail>=6.3,<6.4
 
 commands_pre =
     python testmanage.py makemigrations --settings=tests.settings

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 min_version = 4.0
 
 envlist =
-    python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.1,6.2,6.3}
-    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.1,6.2,6.3}
+    python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.2,6.3}
+    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.2,6.3}
     python{3.10,3.11,3.12}-django5.1-wagtail6.3
 
 [gh-actions]


### PR DESCRIPTION
# Adjust tox testing for Wagtail 6.3

When merged this will:

- Add testing for Wagtail 6.3
- Add testing for Django 5.1 along with Wagtail 6.3 only
- Updates tox and CI actions to reflect dropping tests for python 3.8

I didn't find any code base changes required for the newer versions of Wagtail and Django