### PR TITLE
Adjust tox testing for Wagtail 6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Update tox testing to include Wagtail 6.3
+- Update tox testing to include Wagtail 6.3 and 6.4
 - Add tox testing for Django 5.1
 - Drop testing around python 3.8
 

--- a/README.md
+++ b/README.md
@@ -208,11 +208,11 @@ tox
 To run tests for a specific environment:
 
 ```shell
-tox -e python3.12-django5.0-wagtail6.0
+tox -e python3.12-django5.0-wagtail5.2
 ```
 
 To run a single test method in a specific environment:
 
 ```shell
-tox -e python3.12-django5.0-wagtail6.0 -- tests.test.test_blocks.TestBlocks.test_block_with_features
+tox -e python3.12-django5.0-wagtail5.2 -- tests.test.test_blocks.TestBlocks.test_block_with_features
 ```

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 min_version = 4.22
 
 envlist =
-    python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.2,6.3}
-    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.2,6.3}
-    python{3.12,3.13}-django5.1-wagtail6.3
+    python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.3,6.4}
+    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.3,6.4}
+    python{3.12,3.13}-django5.1-wagtail{6.3,6.4}
 
 [gh-actions]
 python =
@@ -12,6 +12,7 @@ python =
     3.10: python3.10
     3.11: python3.11
     3.12: python3.12
+    3.13: python3.13
 
 
 [testenv]
@@ -35,6 +36,7 @@ deps =
     wagtail5.2: wagtail>=5.2,<5.3
     wagtail6.2: wagtail>=6.2,<6.3
     wagtail6.3: wagtail>=6.3,<6.4
+    wagtail6.3: wagtail>=6.4,<6.5
 
 
 extras = testing

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ deps =
     wagtail5.2: wagtail>=5.2,<5.3
     wagtail6.2: wagtail>=6.2,<6.3
     wagtail6.3: wagtail>=6.3,<6.4
-    wagtail6.3: wagtail>=6.4,<6.5
+    wagtail6.4: wagtail>=6.4,<6.5
 
 
 extras = testing


### PR DESCRIPTION
When merged, this PR will:

- Add testing for Wagtail 6.4
- Add testing for Django 5.1 with Wagtail 6.4 and Python 3.13