### PR TITLE
Update testing for Wagtail 7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-- Update tox testing to include Wagtail 6.3 and 6.4
+- Update tox testing to include Wagtail 6.3 and 6.4 and 7.0
 - Add tox testing for Django 5.1
-- Drop testing around python 3.8
+- Drop testing around python 3.8, Django 5.0
 
 ## 0.13.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 min_version = 4.22
 
 envlist =
-    python{3.9,3.10,3.11}-django4.2-wagtail{5.2,6.3,6.4}
-    python{3.10,3.11,3.12}-django5.0-wagtail{5.2,6.3,6.4}
-    python{3.12,3.13}-django5.1-wagtail{6.3,6.4}
+    python{3.9,3.10,3.11}-django4.2-wagtail{6.3,6.4,7.0}
+    python{3.12,3.13}-django5.1-wagtail{6.3,6.4,7.0}
+    python{3.10,3.11,3.12}-django5.2-wagtail{6.3,6.4,7.0}
 
 [gh-actions]
 python =
@@ -30,12 +30,12 @@ set_env =
 
 deps =
     django4.2: Django>=4.2,<4.3
-    django5.0: Django>=5.0,<5.1
     django5.1: Django>=5.1,<5.2
+    django5.2: Django>=5.2,<5.3
 
-    wagtail5.2: wagtail>=5.2,<5.3
     wagtail6.3: wagtail>=6.3,<6.4
     wagtail6.4: wagtail>=6.4,<6.5
+    wagtail7.0: wagtail>=7.0,<7.1
 
 
 extras = testing


### PR DESCRIPTION
When applied this MR will update the tox testing matrix to include Wagtail 7.0 and drop unsupported versions of Wagtail and Django