### PR TITLE
Wagtail 72 maintenance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ env:
   TOX_TESTENV_PASSENV: FORCE_COLOR
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
   PIP_NO_PYTHON_VERSION_WARNING: "1"
-  PYTHON_LATEST: "3.13"
+  PYTHON_LATEST: "3.14"
 
 
 jobs:
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ ci:
   autofix_prs: false
 
 default_language_version:
-  python: python3.13
+  python: python3.14
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -19,7 +19,7 @@ repos:
     - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Keep in sync with .github/workflows/ruff.yml
-    rev: 'v0.14.2'
+    rev: 'v0.14.4'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Remove support for Wagtail <7.0, Python < 3.10
+- Update tox testing to include Wagtail 7.2
+- Include Python 3.14 in testing
+
 ## 0.14.0
 
 - Remove support for Wagtail <6.3, Python < 3.9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,33 +17,32 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 6",
     "Framework :: Wagtail :: 7",
 ]
 
 dynamic = ["version"]  # will read __version__ from wagtail_footnotes/__init__.py
 requires-python = ">=3.9"
 dependencies = [
-    "Wagtail>=6.3",
+    "Wagtail>=7.0",
     "Django>=4.2",
 ]
 
 [project.optional-dependencies]
 testing = [
-    "pre-commit>=4.3",
-    "tox>=4.22,<5",
-    "coverage>=7.10.6,<8.0",
-    "wagtail-modeladmin>=2.0.0",
+    "pre-commit>=4.4",
+    "tox>=4.32,<5",
+    "coverage>=7.11,<8.0",
+    "wagtail-modeladmin>=2.2.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,14 @@ classifiers = [
     "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
     "Framework :: Wagtail",
+    "Framework :: Wagtail :: 6",
     "Framework :: Wagtail :: 7",
 ]
 
 dynamic = ["version"]  # will read __version__ from wagtail_footnotes/__init__.py
 requires-python = ">=3.9"
 dependencies = [
-    "Wagtail>=7.0",
+    "Wagtail>=6.3",
     "Django>=4.2",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,19 @@
 [tox]
-min_version = 4.22
+min_version = 4.32
+skipmissing_interpreters = true
 
 envlist =
-    python{3.9,3.10}-django4.2-wagtail{6.3}
-    python{3.10,3.11}-django5.1-wagtail{7.0,7.1}
-    python{3.12,3.13}-django5.2-wagtail{7.0,7.1}
+    python{3.10,3.11,3.12}-django4.2-wagtail{7.0,7.1,7.2}
+    python{3.10,3.11,3.12,3.13}-django{5.1,5.2}-wagtail{7.0,7.1,7.2}
+    python3.14-django5.2-wagtail{7.0,7.1,7.2}
 
 [gh-actions]
 python =
-    3.9: python3.9
     3.10: python3.10
     3.11: python3.11
     3.12: python3.12
     3.13: python3.13
+    3.14: python3.14
 
 
 [testenv]
@@ -28,15 +29,16 @@ pass_env =
 set_env =
     python3.12: COVERAGE_CORE=sysmon
     python3.13: COVERAGE_CORE=sysmon
+    python3.14: COVERAGE_CORE=sysmon
 
 deps =
     django4.2: Django>=4.2,<4.3
     django5.1: Django>=5.1,<5.2
     django5.2: Django>=5.2,<5.3
 
-    wagtail6.3: wagtail>=6.3,<6.4
     wagtail7.0: wagtail>=7.0,<7.1
     wagtail7.1: wagtail>=7.1,<7.2
+    wagtail7.2: wagtail>=7.2,<7.3
 
 
 extras = testing

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ min_version = 4.32
 skipmissing_interpreters = true
 
 envlist =
-    python{3.10,3.11}-django4.2-wagtail{7.1}
+    python{3.10,3.11}-django4.2-wagtail{6.3,7.1}
     python{3.12,3.13}-django{5.1,5.2}-wagtail{7.0,7.2}
     python3.14-django5.2-wagtail{7.2}
 
@@ -36,6 +36,7 @@ deps =
     django5.1: Django>=5.1,<5.2
     django5.2: Django>=5.2,<5.3
 
+    wagtail6.3: wagtail>=6.3,<6.4
     wagtail7.0: wagtail>=7.0,<7.1
     wagtail7.1: wagtail>=7.1,<7.2
     wagtail7.2: wagtail>=7.2,<7.3

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,9 @@ min_version = 4.32
 skipmissing_interpreters = true
 
 envlist =
-    python{3.10,3.11,3.12}-django4.2-wagtail{7.0,7.1,7.2}
-    python{3.10,3.11,3.12,3.13}-django{5.1,5.2}-wagtail{7.0,7.1,7.2}
-    python3.14-django5.2-wagtail{7.0,7.1,7.2}
+    python{3.10,3.11}-django4.2-wagtail{7.1}
+    python{3.12,3.13}-django{5.1,5.2}-wagtail{7.0,7.2}
+    python3.14-django5.2-wagtail{7.2}
 
 [gh-actions]
 python =


### PR DESCRIPTION
This pull request updates the project's Python and dependency support to include the latest versions, and aligns the testing and development tooling accordingly. The main changes focus on adding support for Python 3.14, updating Wagtail requirements to version 6.3+, and ensuring all testing environments and pre-commit hooks use the latest compatible versions.

**Python and Dependency Version Support**

* Added support for Python 3.14 across configuration files (`.pre-commit-config.yaml`, `pyproject.toml`, `tox.ini`) and removed Python 3.9 from supported versions. Updated the `classifiers` and test environments to reflect this change.
* Updated required Wagtail version to `>=6.3` 
* Updated Django and Wagtail test matrix to include new combinations for Django 5.1/5.2 and Wagtail 7.0/7.1/7.2, and added corresponding dependency constraints. 

**Tooling and Testing Updates**

* Bumped versions for testing and development tools: `pre-commit`, `tox`, `coverage`, and `wagtail-modeladmin` in `pyproject.toml` 
* Updated `ruff-pre-commit` hook version in `.pre-commit-config.yaml`
* Set `skipmissing_interpreters = true` in `tox.ini` to allow tests to pass even if some Python interpreters are not installed locally.