### PR TITLE
Support multiple references to footnotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Add support for multiple references to the same footnote (https://github.com/torchbox/wagtail-footnotes/pull/90)
+
+  **Breaking change**: The HTML `id` format for in-text footnote reference anchors has changed from
+  `footnote-source-{N}` to `footnote-source-{N}-{M}` (e.g. `footnote-source-1` becomes
+  `footnote-source-1-1`). This applies to all references, including single ones. Sites that target
+  these IDs in CSS, JavaScript, or tests will need to update their selectors.
+
 ## 0.15.0
 
 - Remove support for Wagtail 6.4 and 7.1, Python < 3.10, Django 5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 ## Unreleased
 
-- Add support for multiple references to the same footnote (https://github.com/torchbox/wagtail-footnotes/pull/90)
+## 0.15.0
+
+- Add support for multiple references to the same footnote (https://github.com/torchbox/wagtail-footnotes/pull/90) @jsma
 
   **Breaking change**: The HTML `id` format for in-text footnote reference anchors has changed from
   `footnote-source-{N}` to `footnote-source-{N}-{M}` (e.g. `footnote-source-1` becomes
   `footnote-source-1-1`). This applies to all references, including single ones. Sites that target
   these IDs in CSS, JavaScript, or tests will need to update their selectors.
-
-## 0.15.0
 
 - Remove support for Wagtail 6.4 and 7.1, Python < 3.10, Django 5.1
 - Update tox testing to include Wagtail 7.2 and 7.3, Django 6.0

--- a/tests/templates/test/endnote_reference.html
+++ b/tests/templates/test/endnote_reference.html
@@ -1,1 +1,1 @@
-<a href="#endnote-{{ index }}" id="endnote-source-{{ index }}"><sup>{{ index }}</sup></a>
+<a href="#endnote-{{ index }}" id="endnote-source-{{ index }}-{{ reference_index }}"><sup>{{ index }}</sup></a>

--- a/tests/test/test_blocks.py
+++ b/tests/test/test_blocks.py
@@ -1,4 +1,5 @@
 import json
+import uuid as uuid_module
 
 from django.test import TestCase, override_settings
 from wagtail import blocks
@@ -77,6 +78,62 @@ class TestBlocks(TestCase):
             page=self.test_page_with_multiple_references_to_the_same_footnote,
             uuid=uuid,
             text="This is a footnote",
+        )
+
+        uuid_a = str(uuid_module.uuid4())
+        uuid_b = str(uuid_module.uuid4())
+        self.test_page_counter_isolation = TestPageStreamField(
+            title="Test Page Counter Isolation",
+            slug="test-page-counter-isolation",
+            body=json.dumps(
+                [
+                    {
+                        "type": "paragraph",
+                        "value": (
+                            f'<p>A first <footnote id="{uuid_a}">[{uuid_a[:6]}]</footnote></p>'
+                            f'<p>A second <footnote id="{uuid_a}">[{uuid_a[:6]}]</footnote></p>'
+                            f'<p>B once <footnote id="{uuid_b}">[{uuid_b[:6]}]</footnote></p>'
+                        ),
+                    }
+                ]
+            ),
+        )
+        home_page.add_child(instance=self.test_page_counter_isolation)
+        self.test_page_counter_isolation.save_revision().publish()
+        Footnote.objects.create(
+            page=self.test_page_counter_isolation,
+            uuid=uuid_a,
+            text="Footnote A",
+        )
+        Footnote.objects.create(
+            page=self.test_page_counter_isolation,
+            uuid=uuid_b,
+            text="Footnote B",
+        )
+
+        uuid_cross = str(uuid_module.uuid4())
+        self.test_page_cross_block_refs = TestPageStreamField(
+            title="Test Page Cross Block Refs",
+            slug="test-page-cross-block-refs",
+            body=json.dumps(
+                [
+                    {
+                        "type": "paragraph",
+                        "value": f'<p>Block 1 <footnote id="{uuid_cross}">[{uuid_cross[:6]}]</footnote></p>',
+                    },
+                    {
+                        "type": "paragraph",
+                        "value": f'<p>Block 2 <footnote id="{uuid_cross}">[{uuid_cross[:6]}]</footnote></p>',
+                    },
+                ]
+            ),
+        )
+        home_page.add_child(instance=self.test_page_cross_block_refs)
+        self.test_page_cross_block_refs.save_revision().publish()
+        Footnote.objects.create(
+            page=self.test_page_cross_block_refs,
+            uuid=uuid_cross,
+            text="Cross-block footnote",
         )
 
     def test_block_with_no_features(self):
@@ -169,4 +226,39 @@ class TestBlocks(TestCase):
         html = block.render_footnote_tag(index=2, reference_index=1)
         self.assertHTMLEqual(
             html, '<a href="#endnote-2" id="endnote-source-2-1"><sup>2</sup></a>'
+        )
+
+    def test_block_reference_counters_are_isolated_per_footnote(self):
+        """Reference counter for footnote B starts at 1 and does not bleed from footnote A's count."""
+        body = self.test_page_counter_isolation.body
+        rtb = body.stream_block.child_blocks["paragraph"]
+        value = rtb.get_prep_value(body[0].value)
+        context = self.test_page_counter_isolation.get_context(self.client.get("/"))
+        out = rtb.render(value, context=context)
+        # Footnote A is referenced twice (1-1, 1-2); footnote B's counter resets to 1 (2-1), not 3
+        self.assertHTMLEqual(
+            out,
+            '<p>A first <a href="#footnote-1" id="footnote-source-1-1"><sup>[1]</sup></a></p>'
+            '<p>A second <a href="#footnote-1" id="footnote-source-1-2"><sup>[1]</sup></a></p>'
+            '<p>B once <a href="#footnote-2" id="footnote-source-2-1"><sup>[2]</sup></a></p>',
+        )
+
+    def test_same_footnote_across_multiple_block_renders(self):
+        """footnotes_list persists across block renders so a second-block reference correctly increments."""
+        body = self.test_page_cross_block_refs.body
+        context = self.test_page_cross_block_refs.get_context(self.client.get("/"))
+        rtb = body.stream_block.child_blocks["paragraph"]
+
+        # Render each block in sequence using the same context so footnotes_list accumulates
+        out_block1 = rtb.render(rtb.get_prep_value(body[0].value), context=context)
+        out_block2 = rtb.render(rtb.get_prep_value(body[1].value), context=context)
+
+        # First block gets reference index 1, second block gets reference index 2
+        self.assertHTMLEqual(
+            out_block1,
+            '<p>Block 1 <a href="#footnote-1" id="footnote-source-1-1"><sup>[1]</sup></a></p>',
+        )
+        self.assertHTMLEqual(
+            out_block2,
+            '<p>Block 2 <a href="#footnote-1" id="footnote-source-1-2"><sup>[1]</sup></a></p>',
         )

--- a/tests/test/test_functional.py
+++ b/tests/test/test_functional.py
@@ -78,21 +78,21 @@ class TestFunctional(TestCase):
 
         # Test that required html tags are present with correct
         # attrs that enable the footnotes to respond to clicks
-        source_anchor = soup.find("a", {"id": "footnote-source-1"})
+        source_anchor = soup.find("a", {"id": "footnote-source-1-1"})
         self.assertTrue(source_anchor)
 
         source_anchor_string = str(source_anchor)
         self.assertIn("<sup>[1]</sup>", source_anchor_string)
         self.assertIn('href="#footnote-1"', source_anchor_string)
-        self.assertIn('id="footnote-source-1"', source_anchor_string)
+        self.assertIn('id="footnote-source-1-1"', source_anchor_string)
 
         footnotes = soup.find("div", {"class": "footnotes"})
         self.assertTrue(footnotes)
 
         footnotes_string = str(footnotes)
         self.assertIn('id="footnote-1"', footnotes_string)
-        self.assertIn('href="#footnote-source-1"', footnotes_string)
-        self.assertIn("[1] This is a footnote", footnotes_string)
+        self.assertIn('href="#footnote-source-1-1"', footnotes_string)
+        self.assertIn("This is a footnote", footnotes_string)
 
     def test_edit_page_with_footnote(self):
         self.client.force_login(self.admin_user)

--- a/tests/test/test_functional.py
+++ b/tests/test/test_functional.py
@@ -1,4 +1,5 @@
 import json
+import uuid as uuid_module
 
 from bs4 import BeautifulSoup as bs4
 from django.contrib.auth.models import User
@@ -56,6 +57,85 @@ class TestFunctional(TestCase):
             password="password",  # noqa: S106
         )
 
+        uuid_multi = str(uuid_module.uuid4())
+        self.test_page_multi_refs = TestPageStreamField(
+            title="Test Page Multi Refs",
+            slug="test-page-multi-refs",
+            body=json.dumps(
+                [
+                    {
+                        "type": "paragraph",
+                        "value": (
+                            f'<p>First reference <footnote id="{uuid_multi}">1</footnote>'
+                            f' and second reference <footnote id="{uuid_multi}">1</footnote></p>'
+                        ),
+                    }
+                ]
+            ),
+        )
+        home_page.add_child(instance=self.test_page_multi_refs)
+        self.test_page_multi_refs.save_revision().publish()
+        Footnote.objects.create(
+            page=self.test_page_multi_refs,
+            uuid=uuid_multi,
+            text="Shared footnote",
+        )
+
+        uuid_a = str(uuid_module.uuid4())
+        uuid_b = str(uuid_module.uuid4())
+        self.test_page_two_footnotes = TestPageStreamField(
+            title="Test Page Two Footnotes",
+            slug="test-page-two-footnotes",
+            body=json.dumps(
+                [
+                    {
+                        "type": "paragraph",
+                        "value": (
+                            f'<p>Footnote A <footnote id="{uuid_a}">1</footnote>'
+                            f' and footnote B <footnote id="{uuid_b}">2</footnote></p>'
+                        ),
+                    }
+                ]
+            ),
+        )
+        home_page.add_child(instance=self.test_page_two_footnotes)
+        self.test_page_two_footnotes.save_revision().publish()
+        Footnote.objects.create(
+            page=self.test_page_two_footnotes,
+            uuid=uuid_a,
+            text="Footnote A text",
+        )
+        Footnote.objects.create(
+            page=self.test_page_two_footnotes,
+            uuid=uuid_b,
+            text="Footnote B text",
+        )
+
+        uuid_cross = str(uuid_module.uuid4())
+        self.test_page_cross_blocks = TestPageStreamField(
+            title="Test Page Cross Blocks",
+            slug="test-page-cross-blocks",
+            body=json.dumps(
+                [
+                    {
+                        "type": "paragraph",
+                        "value": f'<p>Block 1 reference <footnote id="{uuid_cross}">1</footnote></p>',
+                    },
+                    {
+                        "type": "paragraph",
+                        "value": f'<p>Block 2 reference <footnote id="{uuid_cross}">1</footnote></p>',
+                    },
+                ]
+            ),
+        )
+        home_page.add_child(instance=self.test_page_cross_blocks)
+        self.test_page_cross_blocks.save_revision().publish()
+        Footnote.objects.create(
+            page=self.test_page_cross_blocks,
+            uuid=uuid_cross,
+            text="Cross-block footnote",
+        )
+
     def test_no_footnote(self):
         response = self.client.get("/test-page-no-footnote/")
         self.assertEqual(response.status_code, 200)
@@ -93,6 +173,57 @@ class TestFunctional(TestCase):
         self.assertIn('id="footnote-1"', footnotes_string)
         self.assertIn('href="#footnote-source-1-1"', footnotes_string)
         self.assertIn("This is a footnote", footnotes_string)
+
+    def test_multiple_references_to_same_footnote_back_links(self):
+        """footnotes.html renders individual back-links for each in-text reference."""
+        response = self.client.get("/test-page-multi-refs/")
+        self.assertEqual(response.status_code, 200)
+        soup = bs4(response.content, "html.parser")
+
+        # Both in-text source anchors are present
+        self.assertTrue(soup.find("a", {"id": "footnote-source-1-1"}))
+        self.assertTrue(soup.find("a", {"id": "footnote-source-1-2"}))
+
+        # The footnote list contains back-links pointing to each source anchor
+        footnotes_string = str(soup.find("div", {"class": "footnotes"}))
+        self.assertIn('href="#footnote-source-1-1"', footnotes_string)
+        self.assertIn('href="#footnote-source-1-2"', footnotes_string)
+        self.assertIn("Shared footnote", footnotes_string)
+
+    def test_two_footnotes_each_referenced_once(self):
+        """Two distinct footnotes each get unique IDs and appear in text order."""
+        response = self.client.get("/test-page-two-footnotes/")
+        self.assertEqual(response.status_code, 200)
+        soup = bs4(response.content, "html.parser")
+
+        # Each footnote's in-text anchor uses its position in footnotes_list as the first index
+        self.assertTrue(soup.find("a", {"id": "footnote-source-1-1"}))
+        self.assertTrue(soup.find("a", {"id": "footnote-source-2-1"}))
+
+        # Both footnotes appear in the list in text order with correct back-links
+        footnotes_string = str(soup.find("div", {"class": "footnotes"}))
+        self.assertIn('id="footnote-1"', footnotes_string)
+        self.assertIn('id="footnote-2"', footnotes_string)
+        self.assertIn('href="#footnote-source-1-1"', footnotes_string)
+        self.assertIn('href="#footnote-source-2-1"', footnotes_string)
+        self.assertIn("Footnote A text", footnotes_string)
+        self.assertIn("Footnote B text", footnotes_string)
+
+    def test_same_footnote_referenced_across_multiple_blocks(self):
+        """A footnote referenced in two separate blocks accumulates back-links correctly."""
+        response = self.client.get("/test-page-cross-blocks/")
+        self.assertEqual(response.status_code, 200)
+        soup = bs4(response.content, "html.parser")
+
+        # footnotes_list persists across block renders, so each block's reference gets a unique anchor
+        self.assertTrue(soup.find("a", {"id": "footnote-source-1-1"}))
+        self.assertTrue(soup.find("a", {"id": "footnote-source-1-2"}))
+
+        # The footnote list back-links cover both in-text occurrences
+        footnotes_string = str(soup.find("div", {"class": "footnotes"}))
+        self.assertIn('href="#footnote-source-1-1"', footnotes_string)
+        self.assertIn('href="#footnote-source-1-2"', footnotes_string)
+        self.assertIn("Cross-block footnote", footnotes_string)
 
     def test_edit_page_with_footnote(self):
         self.client.force_login(self.admin_user)

--- a/tests/test/test_translation.py
+++ b/tests/test/test_translation.py
@@ -143,18 +143,18 @@ class TestSubmitPageTranslationView(WagtailTestUtils, TestCase):
 
         # Test that required html tags are present with correct
         # attrs that enable the footnotes to respond to clicks
-        source_anchor = soup.find("a", {"id": "footnote-source-1"})
+        source_anchor = soup.find("a", {"id": "footnote-source-1-1"})
         self.assertTrue(source_anchor)
 
         source_anchor_string = str(source_anchor)
         self.assertIn("<sup>[1]</sup>", source_anchor_string)
         self.assertIn('href="#footnote-1"', source_anchor_string)
-        self.assertIn('id="footnote-source-1"', source_anchor_string)
+        self.assertIn('id="footnote-source-1-1"', source_anchor_string)
 
         footnotes = soup.find("div", {"class": "footnotes"})
         self.assertTrue(footnotes)
 
         footnotes_string = str(footnotes)
         self.assertIn('id="footnote-1"', footnotes_string)
-        self.assertIn('href="#footnote-source-1"', footnotes_string)
-        self.assertIn("[1] This is a French translated footnote", footnotes_string)
+        self.assertIn('href="#footnote-source-1-1"', footnotes_string)
+        self.assertIn("This is a French translated footnote", footnotes_string)

--- a/wagtail_footnotes/blocks.py
+++ b/wagtail_footnotes/blocks.py
@@ -1,11 +1,12 @@
 import re
 
 from django.conf import settings
-from django.core.exceptions import ValidationError
 from django.template.loader import get_template
 from django.utils.safestring import mark_safe
 from wagtail.blocks import RichTextBlock
 from wagtail.models import Page
+
+from wagtail_footnotes.models import Footnote
 
 
 FIND_FOOTNOTE_TAG = re.compile(r'<footnote id="(.*?)">.*?</footnote>')
@@ -15,10 +16,12 @@ class RichTextBlockWithFootnotes(RichTextBlock):
     """
     Rich Text block that renders footnotes in the format
     '<footnote id="long-id">short-id</footnote>' as anchor elements. It also
-    adds the Footnote object to the 'page' object for later use. It uses
+    adds the Footnote object(s) to the 'page' object for later use. It uses
     'page' because variables added to 'context' do not persist into the
     final template context.
     """
+
+    all_footnotes: dict[str, Footnote]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -27,14 +30,14 @@ class RichTextBlockWithFootnotes(RichTextBlock):
         if "footnotes" not in self.features:
             self.features.append("footnotes")
 
-    def render_footnote_tag(self, index):
+    def render_footnote_tag(self, index: int, reference_index: int):
         template_name = getattr(
             settings,
             "WAGTAIL_FOOTNOTES_REFERENCE_TEMPLATE",
             "wagtail_footnotes/includes/footnote_reference.html",
         )
         template = get_template(template_name)
-        return template.render({"index": index})
+        return template.render({"index": index, "reference_index": reference_index})
 
     def replace_footnote_tags(self, value, html, context=None):
         if context is None:
@@ -42,42 +45,64 @@ class RichTextBlockWithFootnotes(RichTextBlock):
         else:
             new_context = self.get_context(value, parent_context=dict(context))
 
-        if not isinstance(new_context.get("page"), Page):
+        page = new_context.get("page")
+        if page is None or not isinstance(page, Page):
             return html
 
-        page = new_context["page"]
-        if not hasattr(page, "footnotes_list"):
-            page.footnotes_list = []
-        self.footnotes = {
+        # Map Footnote UUIDs to Footnote instances to simplify lookups once a reference has been found in the text.
+        # NOTE: Footnotes may exist in the database for a given page but this does not necessarily mean that the
+        # footnote was referenced in the text.
+        self.all_footnotes = {
             str(footnote.uuid): footnote for footnote in page.footnotes.all()
         }
 
+        # Patch the page to track the footnotes that are actually referenced in the text, so that they can be rendered
+        # in footnotes.html
+        if not hasattr(page, "footnotes_list"):
+            page.footnotes_list = []
+
         def replace_tag(match):
+            footnote_uuid = match.group(1)
             try:
-                index = self.process_footnote(match.group(1), page)
-            except (KeyError, ValidationError):
+                footnote = self.attach_footnote_to_page(footnote_uuid, page)
+            except KeyError:
                 return ""
             else:
-                return self.render_footnote_tag(index)
+                # Add 1 to the footnote index as footnotes are rendered in footnotes.html using `{{ forloop.counter }}`
+                # which is 1-based.
+                footnote_index = page.footnotes_list.index(footnote) + 1
+                reference_index = footnote.references[-1]
+                # Supplying both indexes allows for unique id values to be generated in the HTML. E.g., the first
+                # reference to the first footnote will have `id="footnote-source-1-1"`, and the second reference to the
+                # first footnote will have `id="footnote-source-1-2"`, etc.
+                return self.render_footnote_tag(footnote_index, reference_index)
 
         # note: we return safe html
         return mark_safe(FIND_FOOTNOTE_TAG.sub(replace_tag, html))  # noqa: S308
 
     def render(self, value, context=None):
-        if not self.get_template(value=value, context=context):
-            return self.render_basic(value, context=context)
-
         html = super().render(value, context=context)
         return self.replace_footnote_tags(value, html, context=context)
 
-    def render_basic(self, value, context=None):
-        html = super().render_basic(value, context)
+    def attach_footnote_to_page(self, footnote_uuid: str, page: Page) -> Footnote:
+        """Finds the Footnote object matching `footnote_uuid`, then modifies it to track how many times it has been
+        referenced, and attaches it to the `page` so the footnote can be rendered in the page template.
+        """
+        # Fetch the unmodified Footnote
+        footnote = self.all_footnotes[footnote_uuid]
 
-        return self.replace_footnote_tags(value, html, context=context)
-
-    def process_footnote(self, footnote_id, page):
-        footnote = self.footnotes[footnote_id]
+        # If this is the first time the Footnote has been referenced, modify it to track references before appending it
+        # to the page
         if footnote not in page.footnotes_list:
+            footnote.references = [1]
             page.footnotes_list.append(footnote)
-        # Add 1 to the index as footnotes are indexed starting at 1 not 0.
-        return page.footnotes_list.index(footnote) + 1
+        else:
+            # If this Footnote has been processed by a previous reference, fetch the modified Footnote from the page and
+            # update its reference tracking
+            footnote_index = page.footnotes_list.index(footnote)
+            footnote = page.footnotes_list[footnote_index]
+            # Update the references e.g., [1, 2]
+            footnote.references.append(footnote.references[-1] + 1)
+            # Update the page with the updated footnote
+            page.footnotes_list[footnote_index] = footnote
+        return footnote

--- a/wagtail_footnotes/blocks.py
+++ b/wagtail_footnotes/blocks.py
@@ -56,10 +56,13 @@ class RichTextBlockWithFootnotes(RichTextBlock):
             str(footnote.uuid): footnote for footnote in page.footnotes.all()
         }
 
-        # Patch the page to track the footnotes that are actually referenced in the text, so that they can be rendered
-        # in footnotes.html
+        # Patch the page with `footnotes_list`: the ordered list of Footnote objects actually referenced in the
+        # rich text, used by footnotes.html to render the footnote list at the bottom of the page.
+        # This is distinct from `footnote.references` on each Footnote, which is a list of 1-based reference
+        # indexes tracking each individual in-text occurrence of that footnote (e.g. [1], [1, 2]), used to
+        # render unique back-links from each footnote to its source(s) in the content.
         if not hasattr(page, "footnotes_list"):
-            page.footnotes_list = []
+            page.footnotes_list: list[Footnote] = []
 
         def replace_tag(match):
             footnote_uuid = match.group(1)
@@ -85,8 +88,13 @@ class RichTextBlockWithFootnotes(RichTextBlock):
         return self.replace_footnote_tags(value, html, context=context)
 
     def attach_footnote_to_page(self, footnote_uuid: str, page: Page) -> Footnote:
-        """Finds the Footnote object matching `footnote_uuid`, then modifies it to track how many times it has been
-        referenced, and attaches it to the `page` so the footnote can be rendered in the page template.
+        """Finds the Footnote object matching `footnote_uuid`, then attaches it to `page.footnotes_list` (if not
+        already present) and updates `footnote.references` to record this in-text occurrence.
+
+        `footnote.references` is a list of 1-based indexes, one per in-text occurrence of the footnote
+        (e.g. [1] for a single reference, [1, 2] for two). These indexes are used to generate unique
+        anchor IDs (e.g. ``footnote-source-1-1``, ``footnote-source-1-2``) so each back-link in the
+        footnote list can point to its specific source location in the content.
         """
         # Fetch the unmodified Footnote
         footnote = self.all_footnotes[footnote_uuid]
@@ -94,7 +102,7 @@ class RichTextBlockWithFootnotes(RichTextBlock):
         # If this is the first time the Footnote has been referenced, modify it to track references before appending it
         # to the page
         if footnote not in page.footnotes_list:
-            footnote.references = [1]
+            footnote.references: list[int] = [1]
             page.footnotes_list.append(footnote)
         else:
             # If this Footnote has been processed by a previous reference, fetch the modified Footnote from the page and

--- a/wagtail_footnotes/templates/wagtail_footnotes/includes/footnote_reference.html
+++ b/wagtail_footnotes/templates/wagtail_footnotes/includes/footnote_reference.html
@@ -1,1 +1,1 @@
-<a href="#footnote-{{ index }}" id="footnote-source-{{ index }}"><sup>[{{ index }}]</sup></a>
+<a href="#footnote-{{ index }}" id="footnote-source-{{ index }}-{{ reference_index }}"><sup>[{{ index }}]</sup></a>

--- a/wagtail_footnotes/templates/wagtail_footnotes/includes/footnotes.html
+++ b/wagtail_footnotes/templates/wagtail_footnotes/includes/footnotes.html
@@ -7,10 +7,27 @@
         </h2>
         <ol>
             {% for footnote in page.footnotes_list %}
-                <li id="footnote-{{ forloop.counter }}">
-                    [{{ forloop.counter }}] {{ footnote.text|richtext }}
-                    <a href="#footnote-source-{{ forloop.counter }}" aria-label="{% translate "Back to content" %}">↩</a>
+                {% with footnote_index=forloop.counter %}
+                <li id="footnote-{{ footnote_index }}">
+                    {% if footnote.references|length == 1 %}
+                        {# If there is only a single reference, link the return icon back to it #}
+                        <a href="#footnote-source-{{ footnote_index }}-{{ footnote.references.0 }}" aria-label={% translate "Back to content" %}>
+                            ↩
+                        </a>
+                    {% else %}
+                        ↩
+                        {% for reference_index in footnote.references %}
+                            {# If there are multiple references, generate unique links per reference #}
+                            <a href="#footnote-source-{{ footnote_index }}-{{ reference_index }}" aria-label={% translate "Back to content" %}>
+                                <sup>{# Display a 1-indexed counter for each of the references to this footnote #}
+                                    {{ forloop.counter }}
+                                </sup>
+                            </a>
+                        {% endfor %}
+                    {% endif %}
+                    {{ footnote.text|richtext }}
                 </li>
+                {% endwith %}
             {% endfor %}
         </ol>
     </div>

--- a/wagtail_footnotes/templates/wagtail_footnotes/includes/footnotes.html
+++ b/wagtail_footnotes/templates/wagtail_footnotes/includes/footnotes.html
@@ -11,14 +11,14 @@
                 <li id="footnote-{{ footnote_index }}">
                     {% if footnote.references|length == 1 %}
                         {# If there is only a single reference, link the return icon back to it #}
-                        <a href="#footnote-source-{{ footnote_index }}-{{ footnote.references.0 }}" aria-label={% translate "Back to content" %}>
+                        <a href="#footnote-source-{{ footnote_index }}-{{ footnote.references.0 }}" aria-label="{% translate "Back to content" %}">
                             ↩
                         </a>
                     {% else %}
                         ↩
                         {% for reference_index in footnote.references %}
                             {# If there are multiple references, generate unique links per reference #}
-                            <a href="#footnote-source-{{ footnote_index }}-{{ reference_index }}" aria-label={% translate "Back to content" %}>
+                            <a href="#footnote-source-{{ footnote_index }}-{{ reference_index }}" aria-label="{% translate "Back to content" %}">
                                 <sup>{# Display a 1-indexed counter for each of the references to this footnote #}
                                     {{ forloop.counter }}
                                 </sup>


### PR DESCRIPTION
## Summary

Previously, each footnote could only be referenced once in the page content. This PR adds support for referencing the same footnote multiple times, with unique back-links from the footnote list to each in-text occurrence.

### History

This PR is based on https://github.com/torchbox/wagtail-footnotes/pull/40. I'ts open as a new PR here to add a few extra touches.

Along with the initial PR from @jsma on #40 - I've implemented the following here:

- [Fix missing quotes around aria-label attribute values in footnotes template](https://github.com/torchbox/wagtail-footnotes/pull/90/changes/f90266e6c535ac3a7d09883825769fb47454c2e0) 
- [Add comments and type hints to clarify footnotes_list vs footnote.references](https://github.com/torchbox/wagtail-footnotes/pull/90/changes/c7ec01123cd2c135ab477382340b3108f3d8689d)
- [Document breaking HTML ID change in CHANGELOG for multiple footnote references](https://github.com/torchbox/wagtail-footnotes/pull/90/changes/b0848aa071b11a27a01536ad97690aaba6f5aaf5)
- [Add tests for multiple footnote reference scenarios](https://github.com/torchbox/wagtail-footnotes/pull/90/changes/d45eb7d93c02aff85fc4292bc72080cde24b444d)

> [!CAUTION]
> ### Breaking change
>
> The HTML id format for in-text footnote reference anchors has changed from footnote-source-{N}  to footnote-source-{N}-{M} for all references, including single ones (e.g. footnote-source-1 > footnote-source-1-1). Sites targeting these IDs in CSS, JavaScript, or tests will need to update  their selectors.

###  Tests

Five new tests cover the scenarios this feature introduces:
  - footnotes.html back-links render correctly for a footnote referenced multiple times
  - Two distinct footnotes each referenced once get correct IDs and appear in text order
  - A footnote referenced across two separate stream blocks accumulates references correctly
  - Reference counters are isolated per footnote and don't bleed across different footnotes
  - Block-level rendering correctly increments the reference counter across sequential renders

### Original PR notes:

> This is an attempt to fix https://github.com/torchbox/wagtail-footnotes/issues/25

> At present, this only ensures that each linked reference will have a unique HTML id so that the back links on the footnotes will work (by linking to the first reference). This does not yet include UI changes to expose links to each individual reference in the content but there is a proposed approach in https://github.com/torchbox/wagtail-footnotes/issues/25#issue-1149764004.

