### PR TITLE
Ux improvements

### DIFF
--- a/tests/test/test_functional.py
+++ b/tests/test/test_functional.py
@@ -225,6 +225,26 @@ class TestFunctional(TestCase):
         self.assertIn('href="#footnote-source-1-2"', footnotes_string)
         self.assertIn("Cross-block footnote", footnotes_string)
 
+    def test_footnotes_modal_contains_create_button(self):
+        """The footnote chooser modal renders the 'Create new footnote' button."""
+        response = self.client.get("/footnotes/footnotes_modal/")
+        self.assertEqual(response.status_code, 200)
+
+        soup = bs4(response.content, "html.parser")
+
+        # The button must be present and targetable by the JS via its id
+        create_btn = soup.find("button", {"id": "footnotes-create-new"})
+        self.assertIsNotNone(create_btn)
+        self.assertIn("Create new footnote", create_btn.text)
+
+    def test_footnotes_modal_no_longer_instructs_manual_scroll(self):
+        """The old 'close this window and scroll down' instruction has been removed."""
+        response = self.client.get("/footnotes/footnotes_modal/")
+        self.assertEqual(response.status_code, 200)
+
+        # Regression guard: this copy was removed when the button was added
+        self.assertNotContains(response, "close this window")
+
     def test_edit_page_with_footnote(self):
         self.client.force_login(self.admin_user)
 

--- a/tests/test/test_functional.py
+++ b/tests/test/test_functional.py
@@ -226,24 +226,53 @@ class TestFunctional(TestCase):
         self.assertIn("Cross-block footnote", footnotes_string)
 
     def test_footnotes_modal_contains_create_button(self):
-        """The footnote chooser modal renders the 'Create new footnote' button."""
+        """The footnote chooser modal must render a 'Create new footnote' button.
+
+        Previously users had to close the modal, scroll to the Footnotes panel,
+        add a row there, then reopen the modal to select it — a round-trip that
+        was confusing. The button short-circuits this by letting the user create
+        a footnote directly from the chooser.
+
+        The button's id attribute is load-bearing: footnotes.js selects it via
+        '#footnotes-create-new' to attach the click handler that inserts the
+        Draft.js entity and wires up the new inline panel row.
+        """
         response = self.client.get("/footnotes/footnotes_modal/")
         self.assertEqual(response.status_code, 200)
 
         soup = bs4(response.content, "html.parser")
-
-        # The button must be present and targetable by the JS via its id
         create_btn = soup.find("button", {"id": "footnotes-create-new"})
         self.assertIsNotNone(create_btn)
         self.assertIn("Create new footnote", create_btn.text)
 
     def test_footnotes_modal_no_longer_instructs_manual_scroll(self):
-        """The old 'close this window and scroll down' instruction has been removed."""
+        """The old manual-scroll instruction must be absent from the modal.
+
+        The original modal told users to 'close this window and scroll to the
+        Footnotes section' to add a new footnote. Now that the 'Create new
+        footnote' button handles this automatically, that instruction is
+        misleading and has been removed. This test guards against it being
+        re-introduced.
+        """
+        response = self.client.get("/footnotes/footnotes_modal/")
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "close this window")
+
+    def test_footnotes_modal_does_not_use_w_tabs_controller(self):
+        """The modal must not activate Wagtail's w-tabs Stimulus controller.
+
+        The modal uses w-tabs CSS classes for layout, but the w-tabs Stimulus
+        controller requires a child element with role='tablist' — which the modal
+        doesn't have. If data-controller='w-tabs' is present, Stimulus throws a
+        console error on every modal open. We keep the CSS classes but must not
+        activate the controller.
+        """
         response = self.client.get("/footnotes/footnotes_modal/")
         self.assertEqual(response.status_code, 200)
 
-        # Regression guard: this copy was removed when the button was added
-        self.assertNotContains(response, "close this window")
+        # Check both quote styles to catch either form of the attribute
+        self.assertNotContains(response, 'data-controller="w-tabs"')
+        self.assertNotContains(response, "data-controller='w-tabs'")
 
     def test_edit_page_with_footnote(self):
         self.client.force_login(self.admin_user)

--- a/tests/test/test_widgets.py
+++ b/tests/test/test_widgets.py
@@ -13,3 +13,32 @@ class TestWidgets(TestCase):
             '<input type="hidden" name="uuid" id="id_uuid" data-controller="read-only-uuid">',
             form.as_p(),
         )
+
+    def test_display_value_div_rendered_with_correct_id(self):
+        """The display div must use the predictable ID pattern `{input_id}_display-value`.
+
+        This ID is load-bearing: the "Create new footnote" JS stamps the UUID
+        into it (Feature 1) and the "Go to reference" back-link is inserted
+        immediately after it (Feature 3). If the ID format changes, both
+        features silently break.
+        """
+        widget = ReadonlyUUIDInput()
+        html = widget.render(
+            "uuid", "f291a4b7-5ac5-4030-b341-b1993efb2ad2", attrs={"id": "id_uuid"}
+        )
+
+        self.assertIn('id="id_uuid_display-value"', html)
+
+    def test_display_value_shows_first_six_chars_of_uuid(self):
+        """The visible display truncates the UUID to 6 chars — matching the
+        short key used in the Draftail editor and the chooser modal table."""
+        from bs4 import BeautifulSoup
+
+        widget = ReadonlyUUIDInput()
+        full_uuid = "f291a4b7-5ac5-4030-b341-b1993efb2ad2"
+        html = widget.render("uuid", full_uuid, attrs={"id": "id_uuid"})
+
+        soup = BeautifulSoup(html, "html.parser")
+        display_div = soup.find("div", {"id": "id_uuid_display-value"})
+        self.assertIsNotNone(display_div)
+        self.assertEqual(display_div.text, "f291a4")

--- a/wagtail_footnotes/static/footnotes/css/footnotes-admin.css
+++ b/wagtail_footnotes/static/footnotes/css/footnotes-admin.css
@@ -1,0 +1,33 @@
+/* In-text footnote reference rendered by the Draftail editor decorator */
+.footnote-ref-sup {
+  cursor: pointer;
+  color: var(--w-color-text-link-default);
+  text-decoration: underline;
+}
+
+/* Back-link container injected below the footnote UUID display */
+.footnote-back-links {
+  margin-top: 4px;
+  font-size: 0.85em;
+}
+
+/* Individual back-link button — navigates to an in-text reference */
+.footnote-back-link {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  color: var(--w-color-text-link-default);
+  text-decoration: underline;
+  margin-right: 4px;
+}
+
+.footnote-back-link:hover {
+  text-decoration: none;
+}
+
+/* Chooser modal table rows */
+#footnotes-listing tbody tr {
+  cursor: pointer;
+}

--- a/wagtail_footnotes/static/footnotes/js/footnotes.js
+++ b/wagtail_footnotes/static/footnotes/js/footnotes.js
@@ -266,31 +266,20 @@ document.addEventListener("DOMContentLoaded", function () {
     const container = document.createElement("div");
     container.className = "footnote-back-links";
 
-    if (refs.length === 1) {
-      // Single reference — one plain button
+    if (refs.length > 1) {
+      container.appendChild(document.createTextNode("↑ Go to reference: "));
+    }
+
+    refs.forEach(function (ref, i) {
       const btn = document.createElement("button");
       btn.type = "button";
       btn.className = "footnote-back-link";
-      btn.textContent = "↑ Go to reference";
+      btn.textContent = refs.length > 1 ? i + 1 : "↑ Go to reference";
       btn.addEventListener("click", function () {
-        refs[0].scrollIntoView({ behavior: "smooth", block: "center" });
+        ref.scrollIntoView({ behavior: "smooth", block: "center" });
       });
       container.appendChild(btn);
-    } else {
-      // Multiple references — "↑ " label followed by numbered buttons "1 2 3 …"
-      container.appendChild(document.createTextNode("↑ Go to reference: "));
-
-      refs.forEach(function (ref, i) {
-        const btn = document.createElement("button");
-        btn.type = "button";
-        btn.className = "footnote-back-link";
-        btn.textContent = i + 1;
-        btn.addEventListener("click", function () {
-          ref.scrollIntoView({ behavior: "smooth", block: "center" });
-        });
-        container.appendChild(btn);
-      });
-    }
+    });
 
     // Insert immediately after the UUID display div so the back-link sits just
     // below the footnote's ID — the most natural place to see "where is this used".

--- a/wagtail_footnotes/static/footnotes/js/footnotes.js
+++ b/wagtail_footnotes/static/footnotes/js/footnotes.js
@@ -172,16 +172,19 @@ class FootnoteSource extends React.Component {
 
           // Build the row using DOM methods rather than HTML string concatenation
           // to avoid injection issues with footnote text content.
-          const row = $("<tr>").attr("data-uuid", uuid).css({ cursor: "pointer" });
+          const row = $("<tr>").data("uuid", uuid);
           row.append($("<td>").text(text), $("<td>").text(uuid.substring(0, UUID_SHORT_LENGTH)));
           table.append(row);
+        });
 
-          row.on("click", function () {
-            // Use the row reference from closure rather than navigating from
-            // event.target, which varies depending on which child was clicked.
-            insertFootnoteEntity(row[0].dataset.uuid);
+        // Use event delegation rather than per-row listeners — one handler on the
+        // table catches clicks from any row.
+        table.on("click", "tr", function () {
+          const uuid = $(this).data("uuid");
+          if (uuid) {
+            insertFootnoteEntity(uuid);
             $("#footnotes-modal").modal("hide");
-          });
+          }
         });
 
         $("#footnotes-modal").modal("show");

--- a/wagtail_footnotes/static/footnotes/js/footnotes.js
+++ b/wagtail_footnotes/static/footnotes/js/footnotes.js
@@ -303,8 +303,15 @@ document.addEventListener("DOMContentLoaded", function () {
       });
     }
 
-    // Append below the panel's content area so it doesn't disrupt existing layout
-    panel.appendChild(container);
+    // Insert immediately after the UUID display div so the back-link sits just
+    // below the footnote's ID — the most natural place to see "where is this used".
+    // Falls back to appending to the panel if the display div isn't found.
+    const displayDiv = document.getElementById(`${uuidInput.id}_display-value`);
+    if (displayDiv) {
+      displayDiv.insertAdjacentElement("afterend", container);
+    } else {
+      panel.appendChild(container);
+    }
   }
 
   // Inject into all panels already in the DOM on page load.

--- a/wagtail_footnotes/static/footnotes/js/footnotes.js
+++ b/wagtail_footnotes/static/footnotes/js/footnotes.js
@@ -285,10 +285,8 @@ document.addEventListener("DOMContentLoaded", function () {
         btn.type = "button";
         btn.className = "footnote-back-link";
         btn.textContent = i + 1;
-        // Capture ref in loop-local variable to avoid closure issues
-        const targetRef = ref;
         btn.addEventListener("click", function () {
-          targetRef.scrollIntoView({ behavior: "smooth", block: "center" });
+          ref.scrollIntoView({ behavior: "smooth", block: "center" });
         });
         container.appendChild(btn);
       });

--- a/wagtail_footnotes/static/footnotes/js/footnotes.js
+++ b/wagtail_footnotes/static/footnotes/js/footnotes.js
@@ -198,11 +198,134 @@ class FootnoteSource extends React.Component {
   }
 }
 
+// --- Feature 2: click [fn] in editor → scroll to footnote panel item ---
+//
+// The Footnote decorator renders each in-text reference as a <sup>. We attach
+// a data-footnote-uuid attribute so that panel-side code (Feature 3) can find
+// these elements by UUID, and an onClick handler that scrolls to the matching
+// footnote panel item when the user clicks the reference in the editor.
 const Footnote = (props) => {
   const { entityKey, contentState } = props;
   const data = contentState.getEntity(entityKey).getData();
-  return React.createElement("sup", {}, props.children);
+  const uuid = data.footnote;
+
+  function handleClick(e) {
+    e.preventDefault();
+
+    // Find the hidden UUID input inside the footnote's inline panel row.
+    // The selector matches any input whose id contains "-uuid" and whose value
+    // is the exact UUID for this reference.
+    const uuidInput = document.querySelector(`input[id*="-uuid"][value="${uuid}"]`);
+    if (!uuidInput) return;
+
+    // Walk up to the nearest .w-panel ancestor — that is the inline panel row
+    // for this footnote.
+    const panel = uuidInput.closest(".w-panel");
+    if (!panel) return;
+
+    panel.scrollIntoView({ behavior: "smooth", block: "center" });
+  }
+
+  return React.createElement(
+    "sup",
+    {
+      "data-footnote-uuid": uuid,
+      onClick: handleClick,
+      // Use Wagtail's link colour token so the reference looks like a link in
+      // the editor, consistent with the admin theme.
+      style: { cursor: "pointer", color: "var(--w-color-text-link-default)", textDecoration: "underline" },
+      title: "Go to footnote",
+    },
+    props.children
+  );
 };
+
+// --- Feature 3: "Go to reference" links inside each footnote panel item ---
+//
+// When the edit page loads, each existing inline panel row gets a small set of
+// links that scroll back to the in-text occurrence(s) of that footnote. Because
+// new rows can be added dynamically (via the "Create new footnote" button), we
+// use a MutationObserver to watch for new panels and inject links into them too.
+//
+// We wait for DOMContentLoaded to ensure the inline panel has rendered.
+document.addEventListener("DOMContentLoaded", function () {
+  const panelsContainer = document.getElementById("id_footnotes-FORMS");
+  if (!panelsContainer) return; // not on an edit page
+
+  // Injects "↑ Go to reference" (or numbered links for multiple refs) into a
+  // footnote panel row. Safe to call multiple times — bails if links already
+  // injected for this panel.
+  function injectBackLinks(panel) {
+    if (panel.querySelector(".footnote-back-links")) return;
+
+    const uuidInput = panel.querySelector('input[id*="-uuid"]');
+    if (!uuidInput || !uuidInput.value) return;
+
+    const uuid = uuidInput.value;
+
+    // Find all in-text <sup> elements for this footnote.
+    // These are rendered by the Footnote decorator above with data-footnote-uuid.
+    const refs = document.querySelectorAll(`sup[data-footnote-uuid="${uuid}"]`);
+    if (!refs.length) return;
+
+    const container = document.createElement("div");
+    container.className = "footnote-back-links";
+    container.style.cssText = "margin-top: 4px; font-size: 0.85em;";
+
+    if (refs.length === 1) {
+      // Single reference — one plain "↑" link
+      const link = document.createElement("a");
+      link.href = "#";
+      link.textContent = "↑ Go to reference";
+      link.style.cssText = "cursor: pointer;";
+      link.addEventListener("click", function (e) {
+        e.preventDefault();
+        refs[0].scrollIntoView({ behavior: "smooth", block: "center" });
+      });
+      container.appendChild(link);
+    } else {
+      // Multiple references — "↑ " label followed by numbered links "1 2 3 …"
+      const label = document.createTextNode("↑ Go to reference: ");
+      container.appendChild(label);
+
+      refs.forEach(function (ref, i) {
+        const link = document.createElement("a");
+        link.href = "#";
+        link.textContent = String(i + 1);
+        link.style.cssText = "cursor: pointer; margin-right: 4px;";
+        // Capture ref in loop-local variable to avoid closure issues
+        const targetRef = ref;
+        link.addEventListener("click", function (e) {
+          e.preventDefault();
+          targetRef.scrollIntoView({ behavior: "smooth", block: "center" });
+        });
+        container.appendChild(link);
+      });
+    }
+
+    // Append below the panel's content area so it doesn't disrupt existing layout
+    panel.appendChild(container);
+  }
+
+  // Inject into all panels already in the DOM on page load.
+  // Deferred so Draftail has time to render <sup data-footnote-uuid> elements
+  // into the main body editor — those elements exist in the document but outside
+  // panelsContainer, so they won't be caught by the observer below.
+  setTimeout(function () {
+    panelsContainer.querySelectorAll(".w-panel").forEach(injectBackLinks);
+  }, 500);
+
+  // Watch for new panels added dynamically (e.g. via "Create new footnote")
+  // and inject back-links as soon as each one appears.
+  //
+  // childList-only (no subtree) so this doesn't fire on every keystroke inside
+  // the footnote text editors — we only care about panel rows being added/removed.
+  const panelObserver = new MutationObserver(function () {
+    panelsContainer.querySelectorAll(".w-panel").forEach(injectBackLinks);
+  });
+
+  panelObserver.observe(panelsContainer, { childList: true });
+});
 
 window.draftail.registerPlugin({
   type: "FOOTNOTES",

--- a/wagtail_footnotes/static/footnotes/js/footnotes.js
+++ b/wagtail_footnotes/static/footnotes/js/footnotes.js
@@ -32,6 +32,8 @@ class FootnoteSource extends React.Component {
   componentDidMount() {
     const { editorState, entityType, onComplete } = this.props;
 
+    // Capture content and selection at the time the modal opens — these represent
+    // the editor state at the point the user triggered the footnote chooser.
     const content = editorState.getCurrentContent();
     const selection = editorState.getSelection();
 
@@ -46,6 +48,104 @@ class FootnoteSource extends React.Component {
         var table = $("#footnotes-listing tbody");
         table.empty();
 
+        // --- Shared helper: insert a Draft.js footnote entity at the cursor ---
+        // Creates an IMMUTABLE entity for the given UUID and inserts "[shortid]"
+        // as the visible text at the current selection in the rich text editor.
+        function insertFootnoteEntity(uuid) {
+          const contentWithEntity = content.createEntity(
+            entityType.type,
+            "IMMUTABLE",
+            { footnote: uuid }
+          );
+          const entityKey = contentWithEntity.getLastCreatedEntityKey();
+
+          // The short key is the first 6 chars of the UUID — used as visible text
+          // in the editor. On the published page this is replaced by a numbered ref.
+          const shortKey = uuid.substring(0, 6);
+          const text = `[${shortKey}]`;
+
+          const newContent = Modifier.replaceText(
+            content,
+            selection,
+            text,
+            null,
+            entityKey
+          );
+          const nextState = EditorState.push(
+            editorState,
+            newContent,
+            "insert-characters"
+          );
+
+          onComplete(nextState);
+        }
+
+        // --- "Create new footnote" button handler ---
+        // Closes the modal, triggers the inline panel's "Add" button to create a
+        // new footnote row, scrolls the footnotes section into view, then waits
+        // for the new row's UUID to be populated before inserting the entity.
+        $("#footnotes-create-new").on("click", function () {
+          // Hide the modal before doing anything else so the user can see the panel
+          $("#footnotes-modal").modal("hide");
+
+          // The inline panel "Add" button — standard Wagtail inline panel selector
+          const addButton = document.querySelector("#id_footnotes-ADD");
+          if (!addButton) return;
+          addButton.click();
+
+          // Scroll the footnotes inline panel section into view.
+          // The panel section ID follows Wagtail's naming convention for InlinePanel
+          // fields defined inside the page's content_panels.
+          const footnotesSection = document.querySelector(
+            "#panel-child-content-footnotes-section"
+          );
+          if (footnotesSection) {
+            footnotesSection.scrollIntoView({ behavior: "smooth" });
+          }
+
+          // Watch for the new inline panel row to be added to the DOM.
+          // We can't use setTimeout here because the render time is unpredictable —
+          // MutationObserver lets us react precisely when the new row appears.
+          const formsContainer = document.querySelector("#id_footnotes-FORMS");
+          if (!formsContainer) return;
+
+          const rowObserver = new MutationObserver(function (mutations, rowObs) {
+            for (const mutation of mutations) {
+              for (const node of mutation.addedNodes) {
+                // Only interested in element nodes (not text nodes etc.)
+                if (node.nodeType !== Node.ELEMENT_NODE) continue;
+
+                // The UUID display div is populated by setUUID() once the new row
+                // is initialised. Find it within the newly added panel row.
+                const displayDiv = node.querySelector('div[id$="_display-value"]');
+                if (!displayDiv) continue;
+
+                // Stop watching for new rows — we found the one we want
+                rowObs.disconnect();
+
+                // Now watch the display div for its content being set by setUUID().
+                // setUUID() calls $displayValue.html(...), which triggers a childList
+                // mutation. We use this as the signal that the UUID is ready.
+                const uuidObserver = new MutationObserver(function (_, uuidObs) {
+                  const uuidInput = node.querySelector('input[id*="-uuid"]');
+                  if (!uuidInput || !uuidInput.value) return;
+
+                  // UUID is ready — stop observing and insert the entity
+                  uuidObs.disconnect();
+                  insertFootnoteEntity(uuidInput.value);
+                });
+
+                uuidObserver.observe(displayDiv, { childList: true });
+              }
+            }
+          });
+
+          rowObserver.observe(formsContainer, { childList: true });
+        });
+
+        // --- Existing footnote rows: build the chooser table ---
+        // Reads footnote content and UUIDs from the live inline panel forms
+        // and populates the modal table so the user can pick an existing footnote.
         var live_footnotes = document.querySelectorAll(
           "#id_footnotes-FORMS .w-panel"
         );
@@ -65,36 +165,7 @@ class FootnoteSource extends React.Component {
 
           row.on("click", function (event) {
             const footnoteUUID = event.target.parentElement.dataset["uuid"];
-
-            // Uses the Draft.js API to create a new entity with the right data.
-            const contentWithEntity = content.createEntity(
-              entityType.type,
-              "IMMUTABLE",
-              {
-                footnote: footnoteUUID,
-              }
-            );
-            const entityKey = contentWithEntity.getLastCreatedEntityKey();
-
-            // We also add some text for the entity to be activated on.
-            const shortKey = footnoteUUID.substring(0, 6);
-            const text = `[${shortKey}]`;
-
-            const newContent = Modifier.replaceText(
-              content,
-              selection,
-              text,
-              null,
-              entityKey
-            );
-            const nextState = EditorState.push(
-              editorState,
-              newContent,
-              "insert-characters"
-            );
-
-            onComplete(nextState);
-
+            insertFootnoteEntity(footnoteUUID);
             $("#footnotes-modal").modal("hide");
           });
         });

--- a/wagtail_footnotes/static/footnotes/js/footnotes.js
+++ b/wagtail_footnotes/static/footnotes/js/footnotes.js
@@ -198,12 +198,9 @@ class FootnoteSource extends React.Component {
   }
 }
 
-// --- Feature 2: click [fn] in editor → scroll to footnote panel item ---
-//
-// The Footnote decorator renders each in-text reference as a <sup>. We attach
-// a data-footnote-uuid attribute so that panel-side code (Feature 3) can find
-// these elements by UUID, and an onClick handler that scrolls to the matching
-// footnote panel item when the user clicks the reference in the editor.
+// Renders each in-text footnote reference as a clickable <sup>. Clicking scrolls
+// to the matching footnote panel row. data-footnote-uuid is set so the panel-side
+// back-links can locate this element by UUID.
 const Footnote = (props) => {
   const { entityKey, contentState } = props;
   const data = contentState.getEntity(entityKey).getData();
@@ -240,14 +237,9 @@ const Footnote = (props) => {
   );
 };
 
-// --- Feature 3: "Go to reference" links inside each footnote panel item ---
-//
-// When the edit page loads, each existing inline panel row gets a small set of
-// links that scroll back to the in-text occurrence(s) of that footnote. Because
-// new rows can be added dynamically (via the "Create new footnote" button), we
-// use a MutationObserver to watch for new panels and inject links into them too.
-//
-// We wait for DOMContentLoaded to ensure the inline panel has rendered.
+// Injects "↑ Go to reference" back-links into each footnote inline panel row,
+// positioned just below the short ID. Each link scrolls to the corresponding
+// in-text <sup> in the editor. A MutationObserver handles rows added dynamically.
 document.addEventListener("DOMContentLoaded", function () {
   const panelsContainer = document.getElementById("id_footnotes-FORMS");
   if (!panelsContainer) return; // not on an edit page
@@ -263,8 +255,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
     const uuid = uuidInput.value;
 
-    // Find all in-text <sup> elements for this footnote.
-    // These are rendered by the Footnote decorator above with data-footnote-uuid.
+    // Find all in-text <sup data-footnote-uuid> elements for this footnote.
     const refs = document.querySelectorAll(`sup[data-footnote-uuid="${uuid}"]`);
     if (!refs.length) return;
 

--- a/wagtail_footnotes/static/footnotes/js/footnotes.js
+++ b/wagtail_footnotes/static/footnotes/js/footnotes.js
@@ -267,31 +267,30 @@ document.addEventListener("DOMContentLoaded", function () {
     container.className = "footnote-back-links";
 
     if (refs.length === 1) {
-      // Single reference — one plain "↑" link
-      const link = document.createElement("a");
-      link.href = "#";
-      link.textContent = "↑ Go to reference";
-      link.addEventListener("click", function (e) {
-        e.preventDefault();
+      // Single reference — one plain button
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "footnote-back-link";
+      btn.textContent = "↑ Go to reference";
+      btn.addEventListener("click", function () {
         refs[0].scrollIntoView({ behavior: "smooth", block: "center" });
       });
-      container.appendChild(link);
+      container.appendChild(btn);
     } else {
-      // Multiple references — "↑ " label followed by numbered links "1 2 3 …"
-      const label = document.createTextNode("↑ Go to reference: ");
-      container.appendChild(label);
+      // Multiple references — "↑ " label followed by numbered buttons "1 2 3 …"
+      container.appendChild(document.createTextNode("↑ Go to reference: "));
 
       refs.forEach(function (ref, i) {
-        const link = document.createElement("a");
-        link.href = "#";
-        link.textContent = String(i + 1);
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.className = "footnote-back-link";
+        btn.textContent = String(i + 1);
         // Capture ref in loop-local variable to avoid closure issues
         const targetRef = ref;
-        link.addEventListener("click", function (e) {
-          e.preventDefault();
+        btn.addEventListener("click", function () {
           targetRef.scrollIntoView({ behavior: "smooth", block: "center" });
         });
-        container.appendChild(link);
+        container.appendChild(btn);
       });
     }
 

--- a/wagtail_footnotes/static/footnotes/js/footnotes.js
+++ b/wagtail_footnotes/static/footnotes/js/footnotes.js
@@ -37,10 +37,7 @@ class FootnoteSource extends React.Component {
     const content = editorState.getCurrentContent();
     const selection = editorState.getSelection();
 
-    // Keep a reference to the bound handler so we can remove it selectively.
-    // When the user clicks "Create new footnote" we detach this before hiding the
-    // modal — otherwise the hide event would fire onClose(), which cancels the
-    // Draftail operation before we've had a chance to call onComplete().
+    // Keep a named reference so we can remove this specific handler when needed.
     const modalCloseHandler = this.onClose;
     $(document.body).on("hidden.bs.modal", modalCloseHandler);
 
@@ -86,24 +83,44 @@ class FootnoteSource extends React.Component {
         }
 
         // --- "Create new footnote" button handler ---
-        // Closes the modal, triggers the inline panel's "Add" button to create a
-        // new footnote row, scrolls the footnotes section into view, then waits
-        // for the new row's UUID to be populated before inserting the entity.
+        //
+        // Strategy: generate the UUID up front and insert the entity immediately
+        // (while FootnoteSource is definitely still mounted), then asynchronously
+        // wire up the new inline panel form row to use that same UUID.
+        //
+        // We can't do it the other way round (wait for the form row, read its UUID,
+        // then insert the entity) because Draftail may unmount FootnoteSource at any
+        // point after the modal closes, making onComplete() unreliable to call later.
         $("#footnotes-create-new").on("click", function () {
-          // Detach the modal-close handler BEFORE hiding the modal. If we don't,
-          // Bootstrap fires "hidden.bs.modal" which calls onClose(), and that
-          // cancels the Draftail operation before onComplete() has been called.
+          // Generate the UUID now so we control it from the start
+          const uuid = uuidv4();
+
+          // Read the current total form count BEFORE clicking add — the new form
+          // row will be assigned this index by Django's formset machinery.
+          const totalFormsInput = document.getElementById(
+            "id_footnotes-TOTAL_FORMS"
+          );
+          const newFormIndex = totalFormsInput
+            ? parseInt(totalFormsInput.value, 10)
+            : 0;
+
+          // Insert the entity into the rich text editor right now, while
+          // FootnoteSource is still mounted and onComplete() is safe to call.
+          insertFootnoteEntity(uuid);
+
+          // Remove the modal close handler before hiding so it doesn't fire
+          // onClose() on the (now unmounting) component and cause a double-call.
           $(document.body).off("hidden.bs.modal", modalCloseHandler);
           $("#footnotes-modal").modal("hide");
 
-          // The inline panel "Add" button — standard Wagtail inline panel selector
+          // Click the inline panel "Add" button to create a new form row.
+          // Standard Wagtail inline panel selector.
           const addButton = document.querySelector("#id_footnotes-ADD");
           if (!addButton) return;
           addButton.click();
 
-          // Scroll the footnotes inline panel section into view.
-          // The panel section ID follows Wagtail's naming convention for InlinePanel
-          // fields defined inside the page's content_panels.
+          // Scroll the footnotes panel into view so the user can fill in the text.
+          // The section ID follows Wagtail's InlinePanel naming convention.
           const footnotesSection = document.querySelector(
             "#panel-child-content-footnotes-section"
           );
@@ -111,50 +128,36 @@ class FootnoteSource extends React.Component {
             footnotesSection.scrollIntoView({ behavior: "smooth" });
           }
 
-          const formsContainer = document.querySelector("#id_footnotes-FORMS");
-          if (!formsContainer) return;
+          // Watch for the new form row's UUID input to appear in the DOM, then
+          // set it to our pre-generated UUID. We know the exact ID because Django
+          // formsets use a predictable index (the old TOTAL_FORMS value).
+          //
+          // We observe document.body (not just the forms container) to avoid
+          // missing the element if Wagtail nests the new row inside wrapper elements.
+          const expectedInputId = `id_footnotes-${newFormIndex}-uuid`;
+          const expectedDisplayId = `${expectedInputId}_display-value`;
 
-          // Snapshot which UUID display divs already exist so we can identify the
-          // newly added one. setUUID() populates these divs; a new one with content
-          // means a new footnote row has been initialised and is ready to reference.
-          const existingDisplayDivIds = new Set(
-            Array.from(
-              document.querySelectorAll("div[id*='-uuid_display-value']")
-            ).map((el) => el.id)
-          );
-
-          // Watch the entire forms container (subtree) for any DOM changes.
-          // We need subtree:true because the new panel row may be nested inside
-          // a wrapper element rather than being a direct child of formsContainer.
           const observer = new MutationObserver(function (mutations, obs) {
-            // After each batch of mutations, check whether a new display div has
-            // appeared AND been populated by setUUID(). Both conditions must be
-            // true — the div is added empty first, then populated on the next tick
-            // by the Stimulus read-only-uuid controller.
-            const allDisplayDivs = document.querySelectorAll(
-              "div[id*='-uuid_display-value']"
-            );
-            for (const div of allDisplayDivs) {
-              if (existingDisplayDivIds.has(div.id)) continue; // pre-existing
-              if (!div.textContent.trim()) continue; // not yet populated
+            const uuidInput = document.getElementById(expectedInputId);
+            if (!uuidInput) return; // row not in DOM yet — keep watching
 
-              // Found a new, populated display div. Derive the hidden input's ID
-              // by stripping "_display-value" from the div's id, then read the UUID.
-              const inputId = div.id.replace("_display-value", "");
-              const uuidInput = document.getElementById(inputId);
-              if (!uuidInput || !uuidInput.value) continue;
+            // Found the input — stop observing immediately
+            obs.disconnect();
 
-              // Stop observing — we have what we need
-              obs.disconnect();
-              insertFootnoteEntity(uuidInput.value);
-              return;
+            // Set our UUID on the hidden input. If setUUID() hasn't run yet,
+            // it will see a non-empty value and skip generating its own UUID.
+            // If setUUID() already ran (and generated a different UUID), we
+            // overwrite it so the form row matches the entity we already inserted.
+            uuidInput.value = uuid;
+
+            // Also update the display div so what the user sees matches
+            const displayDiv = document.getElementById(expectedDisplayId);
+            if (displayDiv) {
+              displayDiv.textContent = uuid.substring(0, 6);
             }
           });
 
-          observer.observe(formsContainer, {
-            childList: true,
-            subtree: true,
-          });
+          observer.observe(document.body, { childList: true, subtree: true });
         });
 
         // --- Existing footnote rows: build the chooser table ---

--- a/wagtail_footnotes/static/footnotes/js/footnotes.js
+++ b/wagtail_footnotes/static/footnotes/js/footnotes.js
@@ -1,12 +1,15 @@
+// Number of UUID characters shown in the editor and chooser table.
+// Also used by the display-value div rendered by ReadonlyUUIDInput.
+const UUID_SHORT_LENGTH = 6;
+
 function setUUID(id) {
   const input = document.getElementById(id);
+  if (!input || input.value) return;
+  const uuid = crypto.randomUUID();
+  input.value = uuid;
   const displayValue = document.getElementById(`${id}_display-value`);
-  if (input && !input.value) {
-    const uuid = crypto.randomUUID();
-    input.value = uuid;
-    if (displayValue) {
-      displayValue.textContent = uuid.substring(0, 6);
-    }
+  if (displayValue) {
+    displayValue.textContent = uuid.substring(0, UUID_SHORT_LENGTH);
   }
 }
 
@@ -54,7 +57,7 @@ class FootnoteSource extends React.Component {
 
           // The short key is the first 6 chars of the UUID — used as visible text
           // in the editor. On the published page this is replaced by a numbered ref.
-          const shortKey = uuid.substring(0, 6);
+          const shortKey = uuid.substring(0, UUID_SHORT_LENGTH);
           const newContent = Modifier.replaceText(
             content,
             selection,
@@ -120,7 +123,7 @@ class FootnoteSource extends React.Component {
 
             const displayDiv = document.getElementById(expectedDisplayId);
             if (displayDiv) {
-              displayDiv.textContent = uuid.substring(0, 6);
+              displayDiv.textContent = uuid.substring(0, UUID_SHORT_LENGTH);
             }
 
             // Scroll to the new row and focus its Draftail editor. Deferred because
@@ -170,7 +173,7 @@ class FootnoteSource extends React.Component {
           // Build the row using DOM methods rather than HTML string concatenation
           // to avoid injection issues with footnote text content.
           const row = $("<tr>").attr("data-uuid", uuid).css({ cursor: "pointer" });
-          row.append($("<td>").text(text), $("<td>").text(uuid.substring(0, 6)));
+          row.append($("<td>").text(text), $("<td>").text(uuid.substring(0, UUID_SHORT_LENGTH)));
           table.append(row);
 
           row.on("click", function () {

--- a/wagtail_footnotes/static/footnotes/js/footnotes.js
+++ b/wagtail_footnotes/static/footnotes/js/footnotes.js
@@ -305,6 +305,10 @@ document.addEventListener("DOMContentLoaded", function () {
     }
   }
 
+  // Initial pass — Stimulus initialises Draftail synchronously before this
+  // handler runs, so sups may already be in the DOM at this point.
+  panelsContainer.querySelectorAll(".w-panel").forEach(injectBackLinks);
+
   // Watch for Draftail to render footnote entities in the main body editor.
   // <sup data-footnote-uuid> elements live outside panelsContainer so won't be
   // caught by the panel observer below — we watch document.body instead and

--- a/wagtail_footnotes/static/footnotes/js/footnotes.js
+++ b/wagtail_footnotes/static/footnotes/js/footnotes.js
@@ -284,7 +284,7 @@ document.addEventListener("DOMContentLoaded", function () {
         const btn = document.createElement("button");
         btn.type = "button";
         btn.className = "footnote-back-link";
-        btn.textContent = String(i + 1);
+        btn.textContent = i + 1;
         // Capture ref in loop-local variable to avoid closure issues
         const targetRef = ref;
         btn.addEventListener("click", function () {

--- a/wagtail_footnotes/static/footnotes/js/footnotes.js
+++ b/wagtail_footnotes/static/footnotes/js/footnotes.js
@@ -37,7 +37,12 @@ class FootnoteSource extends React.Component {
     const content = editorState.getCurrentContent();
     const selection = editorState.getSelection();
 
-    $(document.body).on("hidden.bs.modal", this.onClose);
+    // Keep a reference to the bound handler so we can remove it selectively.
+    // When the user clicks "Create new footnote" we detach this before hiding the
+    // modal — otherwise the hide event would fire onClose(), which cancels the
+    // Draftail operation before we've had a chance to call onComplete().
+    const modalCloseHandler = this.onClose;
+    $(document.body).on("hidden.bs.modal", modalCloseHandler);
 
     $("body > .modal").remove();
 
@@ -85,7 +90,10 @@ class FootnoteSource extends React.Component {
         // new footnote row, scrolls the footnotes section into view, then waits
         // for the new row's UUID to be populated before inserting the entity.
         $("#footnotes-create-new").on("click", function () {
-          // Hide the modal before doing anything else so the user can see the panel
+          // Detach the modal-close handler BEFORE hiding the modal. If we don't,
+          // Bootstrap fires "hidden.bs.modal" which calls onClose(), and that
+          // cancels the Draftail operation before onComplete() has been called.
+          $(document.body).off("hidden.bs.modal", modalCloseHandler);
           $("#footnotes-modal").modal("hide");
 
           // The inline panel "Add" button — standard Wagtail inline panel selector
@@ -103,44 +111,50 @@ class FootnoteSource extends React.Component {
             footnotesSection.scrollIntoView({ behavior: "smooth" });
           }
 
-          // Watch for the new inline panel row to be added to the DOM.
-          // We can't use setTimeout here because the render time is unpredictable —
-          // MutationObserver lets us react precisely when the new row appears.
           const formsContainer = document.querySelector("#id_footnotes-FORMS");
           if (!formsContainer) return;
 
-          const rowObserver = new MutationObserver(function (mutations, rowObs) {
-            for (const mutation of mutations) {
-              for (const node of mutation.addedNodes) {
-                // Only interested in element nodes (not text nodes etc.)
-                if (node.nodeType !== Node.ELEMENT_NODE) continue;
+          // Snapshot which UUID display divs already exist so we can identify the
+          // newly added one. setUUID() populates these divs; a new one with content
+          // means a new footnote row has been initialised and is ready to reference.
+          const existingDisplayDivIds = new Set(
+            Array.from(
+              document.querySelectorAll("div[id*='-uuid_display-value']")
+            ).map((el) => el.id)
+          );
 
-                // The UUID display div is populated by setUUID() once the new row
-                // is initialised. Find it within the newly added panel row.
-                const displayDiv = node.querySelector('div[id$="_display-value"]');
-                if (!displayDiv) continue;
+          // Watch the entire forms container (subtree) for any DOM changes.
+          // We need subtree:true because the new panel row may be nested inside
+          // a wrapper element rather than being a direct child of formsContainer.
+          const observer = new MutationObserver(function (mutations, obs) {
+            // After each batch of mutations, check whether a new display div has
+            // appeared AND been populated by setUUID(). Both conditions must be
+            // true — the div is added empty first, then populated on the next tick
+            // by the Stimulus read-only-uuid controller.
+            const allDisplayDivs = document.querySelectorAll(
+              "div[id*='-uuid_display-value']"
+            );
+            for (const div of allDisplayDivs) {
+              if (existingDisplayDivIds.has(div.id)) continue; // pre-existing
+              if (!div.textContent.trim()) continue; // not yet populated
 
-                // Stop watching for new rows — we found the one we want
-                rowObs.disconnect();
+              // Found a new, populated display div. Derive the hidden input's ID
+              // by stripping "_display-value" from the div's id, then read the UUID.
+              const inputId = div.id.replace("_display-value", "");
+              const uuidInput = document.getElementById(inputId);
+              if (!uuidInput || !uuidInput.value) continue;
 
-                // Now watch the display div for its content being set by setUUID().
-                // setUUID() calls $displayValue.html(...), which triggers a childList
-                // mutation. We use this as the signal that the UUID is ready.
-                const uuidObserver = new MutationObserver(function (_, uuidObs) {
-                  const uuidInput = node.querySelector('input[id*="-uuid"]');
-                  if (!uuidInput || !uuidInput.value) return;
-
-                  // UUID is ready — stop observing and insert the entity
-                  uuidObs.disconnect();
-                  insertFootnoteEntity(uuidInput.value);
-                });
-
-                uuidObserver.observe(displayDiv, { childList: true });
-              }
+              // Stop observing — we have what we need
+              obs.disconnect();
+              insertFootnoteEntity(uuidInput.value);
+              return;
             }
           });
 
-          rowObserver.observe(formsContainer, { childList: true });
+          observer.observe(formsContainer, {
+            childList: true,
+            subtree: true,
+          });
         });
 
         // --- Existing footnote rows: build the chooser table ---

--- a/wagtail_footnotes/static/footnotes/js/footnotes.js
+++ b/wagtail_footnotes/static/footnotes/js/footnotes.js
@@ -1,21 +1,12 @@
-function uuidv4() {
-  return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, (c) =>
-    (
-      c ^
-      (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))
-    ).toString(16)
-  );
-}
-
 function setUUID(id) {
-  var $input = $("input#" + id);
-  var $displayValue = $("div#" + id + "_display-value");
-  if (!$input.val()) {
-    var uuid = uuidv4();
-    // Set hidden field
-    $input.val(uuid);
-    // Set displayed text
-    $displayValue.html(uuid.substring(0, 6));
+  const input = document.getElementById(id);
+  const displayValue = document.getElementById(`${id}_display-value`);
+  if (input && !input.value) {
+    const uuid = crypto.randomUUID();
+    input.value = uuid;
+    if (displayValue) {
+      displayValue.textContent = uuid.substring(0, 6);
+    }
   }
 }
 
@@ -47,7 +38,7 @@ class FootnoteSource extends React.Component {
       url: "/footnotes/footnotes_modal/",
       success: function (data) {
         $("body").append(data);
-        var table = $("#footnotes-listing tbody");
+        const table = $("#footnotes-listing tbody");
         table.empty();
 
         // --- Shared helper: insert a Draft.js footnote entity at the cursor ---
@@ -64,22 +55,14 @@ class FootnoteSource extends React.Component {
           // The short key is the first 6 chars of the UUID — used as visible text
           // in the editor. On the published page this is replaced by a numbered ref.
           const shortKey = uuid.substring(0, 6);
-          const text = `[${shortKey}]`;
-
           const newContent = Modifier.replaceText(
             content,
             selection,
-            text,
+            `[${shortKey}]`,
             null,
             entityKey
           );
-          const nextState = EditorState.push(
-            editorState,
-            newContent,
-            "insert-characters"
-          );
-
-          onComplete(nextState);
+          onComplete(EditorState.push(editorState, newContent, "insert-characters"));
         }
 
         // --- "Create new footnote" button handler ---
@@ -89,27 +72,23 @@ class FootnoteSource extends React.Component {
         // wire up the new inline panel form row to use that same UUID.
         //
         // We can't do it the other way round (wait for the form row, read its UUID,
-        // then insert the entity) because Draftail may unmount FootnoteSource at any
-        // point after the modal closes, making onComplete() unreliable to call later.
+        // then insert the entity) because Draftail unmounts FootnoteSource after
+        // onComplete() is called, making it unsafe to call later.
         $("#footnotes-create-new").on("click", function () {
-          // Generate the UUID now so we control it from the start
-          const uuid = uuidv4();
+          const uuid = crypto.randomUUID();
 
           // Read the current total form count BEFORE clicking add — the new form
           // row will be assigned this index by Django's formset machinery.
-          const totalFormsInput = document.getElementById(
-            "id_footnotes-TOTAL_FORMS"
-          );
-          const newFormIndex = totalFormsInput
-            ? parseInt(totalFormsInput.value, 10)
-            : 0;
+          const totalFormsInput = document.getElementById("id_footnotes-TOTAL_FORMS");
+          if (!totalFormsInput) return;
+          const newFormIndex = parseInt(totalFormsInput.value, 10);
 
-          // Insert the entity into the rich text editor right now, while
-          // FootnoteSource is still mounted and onComplete() is safe to call.
+          // Insert the entity while FootnoteSource is still mounted and
+          // onComplete() is safe to call.
           insertFootnoteEntity(uuid);
 
           // Remove the modal close handler before hiding so it doesn't fire
-          // onClose() on the (now unmounting) component and cause a double-call.
+          // onClose() on the now-unmounting component.
           $(document.body).off("hidden.bs.modal", modalCloseHandler);
           $("#footnotes-modal").modal("hide");
 
@@ -119,21 +98,12 @@ class FootnoteSource extends React.Component {
           if (!addButton) return;
           addButton.click();
 
-          // Scroll the footnotes panel into view so the user can fill in the text.
-          // The section ID follows Wagtail's InlinePanel naming convention.
-          const footnotesSection = document.querySelector(
-            "#panel-child-content-footnotes-section"
-          );
-          if (footnotesSection) {
-            footnotesSection.scrollIntoView({ behavior: "smooth" });
-          }
-
           // Watch for the new form row's UUID input to appear in the DOM, then
-          // set it to our pre-generated UUID. We know the exact ID because Django
-          // formsets use a predictable index (the old TOTAL_FORMS value).
+          // stamp it with our pre-generated UUID. We know the exact input ID because
+          // Django formsets use a predictable index (the pre-add TOTAL_FORMS value).
           //
-          // We observe document.body (not just the forms container) to avoid
-          // missing the element if Wagtail nests the new row inside wrapper elements.
+          // We observe document.body to avoid missing the element if Wagtail
+          // nests the new row inside wrapper elements.
           const expectedInputId = `id_footnotes-${newFormIndex}-uuid`;
           const expectedDisplayId = `${expectedInputId}_display-value`;
 
@@ -141,20 +111,50 @@ class FootnoteSource extends React.Component {
             const uuidInput = document.getElementById(expectedInputId);
             if (!uuidInput) return; // row not in DOM yet — keep watching
 
-            // Found the input — stop observing immediately
             obs.disconnect();
 
-            // Set our UUID on the hidden input. If setUUID() hasn't run yet,
-            // it will see a non-empty value and skip generating its own UUID.
-            // If setUUID() already ran (and generated a different UUID), we
-            // overwrite it so the form row matches the entity we already inserted.
+            // Stamp our UUID onto the hidden input. If setUUID() hasn't run yet it
+            // will skip (input is non-empty). If it already ran with a different UUID
+            // we overwrite it so the form row matches the entity we inserted.
             uuidInput.value = uuid;
 
-            // Also update the display div so what the user sees matches
             const displayDiv = document.getElementById(expectedDisplayId);
             if (displayDiv) {
               displayDiv.textContent = uuid.substring(0, 6);
             }
+
+            // Scroll to the new row and focus its Draftail editor. Deferred because
+            // onComplete() causes Draftail to refocus the rich text editor — we run
+            // after that so our scroll and focus take effect last.
+            const newRow = uuidInput.closest(".w-panel");
+            if (!newRow) return;
+
+            setTimeout(function () {
+              newRow.scrollIntoView({ behavior: "smooth", block: "center" });
+
+              // The Draftail editor in the new row may not be initialised yet.
+              // Try immediately, and if not ready, observe until it appears.
+              const existingEditor = newRow.querySelector(".public-DraftEditor-content");
+              if (existingEditor) {
+                existingEditor.focus();
+                return;
+              }
+
+              const editorObserver = new MutationObserver(function (_, editorObs) {
+                const editor = newRow.querySelector(".public-DraftEditor-content");
+                if (!editor) return;
+                editorObs.disconnect();
+                clearTimeout(editorObserverTimeout);
+                editor.focus();
+              });
+              editorObserver.observe(newRow, { childList: true, subtree: true });
+
+              // Disconnect after 5s as a leak guard in case the editor never appears
+              const editorObserverTimeout = setTimeout(
+                () => editorObserver.disconnect(),
+                5000
+              );
+            }, 100);
           });
 
           observer.observe(document.body, { childList: true, subtree: true });
@@ -163,26 +163,20 @@ class FootnoteSource extends React.Component {
         // --- Existing footnote rows: build the chooser table ---
         // Reads footnote content and UUIDs from the live inline panel forms
         // and populates the modal table so the user can pick an existing footnote.
-        var live_footnotes = document.querySelectorAll(
-          "#id_footnotes-FORMS .w-panel"
-        );
-        Array.prototype.forEach.call(live_footnotes, function (value) {
-          const text = $(".public-DraftEditor-content", value).text();
-          const uuid = $('input[id*="-uuid"]', value)[0].value;
-          var row = $(
-            "<tr data-uuid=" +
-            uuid +
-            "><td>" +
-            text +
-            "</td><td>" +
-            uuid.substring(0, 6) +
-            "</td></tr>"
-          ).css({ cursor: "pointer" });
+        document.querySelectorAll("#id_footnotes-FORMS .w-panel").forEach(function (panel) {
+          const text = $(".public-DraftEditor-content", panel).text();
+          const uuid = $('input[id*="-uuid"]', panel)[0].value;
+
+          // Build the row using DOM methods rather than HTML string concatenation
+          // to avoid injection issues with footnote text content.
+          const row = $("<tr>").attr("data-uuid", uuid).css({ cursor: "pointer" });
+          row.append($("<td>").text(text), $("<td>").text(uuid.substring(0, 6)));
           table.append(row);
 
-          row.on("click", function (event) {
-            const footnoteUUID = event.target.parentElement.dataset["uuid"];
-            insertFootnoteEntity(footnoteUUID);
+          row.on("click", function () {
+            // Use the row reference from closure rather than navigating from
+            // event.target, which varies depending on which child was clicked.
+            insertFootnoteEntity(row[0].dataset.uuid);
             $("#footnotes-modal").modal("hide");
           });
         });

--- a/wagtail_footnotes/static/footnotes/js/footnotes.js
+++ b/wagtail_footnotes/static/footnotes/js/footnotes.js
@@ -234,9 +234,7 @@ const Footnote = (props) => {
     {
       "data-footnote-uuid": uuid,
       onClick: handleClick,
-      // Use Wagtail's link colour token so the reference looks like a link in
-      // the editor, consistent with the admin theme.
-      style: { cursor: "pointer", color: "var(--w-color-text-link-default)", textDecoration: "underline" },
+      className: "footnote-ref-sup",
       title: "Go to footnote",
     },
     props.children
@@ -267,14 +265,12 @@ document.addEventListener("DOMContentLoaded", function () {
 
     const container = document.createElement("div");
     container.className = "footnote-back-links";
-    container.style.cssText = "margin-top: 4px; font-size: 0.85em;";
 
     if (refs.length === 1) {
       // Single reference — one plain "↑" link
       const link = document.createElement("a");
       link.href = "#";
       link.textContent = "↑ Go to reference";
-      link.style.cssText = "cursor: pointer;";
       link.addEventListener("click", function (e) {
         e.preventDefault();
         refs[0].scrollIntoView({ behavior: "smooth", block: "center" });
@@ -289,7 +285,6 @@ document.addEventListener("DOMContentLoaded", function () {
         const link = document.createElement("a");
         link.href = "#";
         link.textContent = String(i + 1);
-        link.style.cssText = "cursor: pointer; margin-right: 4px;";
         // Capture ref in loop-local variable to avoid closure issues
         const targetRef = ref;
         link.addEventListener("click", function (e) {

--- a/wagtail_footnotes/static/footnotes/js/footnotes.js
+++ b/wagtail_footnotes/static/footnotes/js/footnotes.js
@@ -305,17 +305,29 @@ document.addEventListener("DOMContentLoaded", function () {
     }
   }
 
-  // Inject into all panels already in the DOM on page load.
-  // Deferred so Draftail has time to render <sup data-footnote-uuid> elements
-  // into the main body editor — those elements exist in the document but outside
-  // panelsContainer, so they won't be caught by the observer below.
-  setTimeout(function () {
-    panelsContainer.querySelectorAll(".w-panel").forEach(injectBackLinks);
-  }, 500);
+  // Watch for Draftail to render footnote entities in the main body editor.
+  // <sup data-footnote-uuid> elements live outside panelsContainer so won't be
+  // caught by the panel observer below — we watch document.body instead and
+  // filter to only act when a relevant element appears.
+  const supObserver = new MutationObserver(function (mutations) {
+    const hasNewSup = mutations.some(function (m) {
+      return Array.from(m.addedNodes).some(function (n) {
+        return (
+          n.nodeType === Node.ELEMENT_NODE &&
+          ((n.tagName === "SUP" && n.hasAttribute("data-footnote-uuid")) ||
+            n.querySelector("sup[data-footnote-uuid]") !== null)
+        );
+      });
+    });
 
-  // Watch for new panels added dynamically (e.g. via "Create new footnote")
-  // and inject back-links as soon as each one appears.
-  //
+    if (!hasNewSup) return;
+
+    panelsContainer.querySelectorAll(".w-panel").forEach(injectBackLinks);
+  });
+
+  supObserver.observe(document.body, { childList: true, subtree: true });
+
+  // Watch for new panels added dynamically (e.g. via "Create new footnote").
   // childList-only (no subtree) so this doesn't fire on every keystroke inside
   // the footnote text editors — we only care about panel rows being added/removed.
   const panelObserver = new MutationObserver(function () {

--- a/wagtail_footnotes/templates/wagtail_footnotes/admin/footnotes_modal.html
+++ b/wagtail_footnotes/templates/wagtail_footnotes/admin/footnotes_modal.html
@@ -24,11 +24,14 @@
                     <div class="tab-content">
                         <div class="w-tabs__panel">
                             <h2>{% translate "Footnotes" %}</h2>
+
                             <p>
-                                {% blocktranslate trimmed %}
-                                    To add a new footnote, close this window and scroll to the "Footnotes" section at bottom of the page.
-                                {% endblocktranslate %}
+                                <button id="footnotes-create-new" type="button" class="button button-secondary">
+                                    {% translate "Create new footnote" %}
+                                </button>
                             </p>
+
+                            <p>{% translate "Or choose an existing footnote:" %}</p>
 
                             <table id="footnotes-listing" class="listing">
                                 <thead>

--- a/wagtail_footnotes/templates/wagtail_footnotes/admin/footnotes_modal.html
+++ b/wagtail_footnotes/templates/wagtail_footnotes/admin/footnotes_modal.html
@@ -19,7 +19,7 @@
                     </div>
                 </header>
 
-                <div class="w-tabs" data-controller="w-tabs" data-tabs="" data-tabs-disable-url="">
+                <div class="w-tabs">
                     <div class="w-tabs__wrapper"></div>
                     <div class="tab-content">
                         <div class="w-tabs__panel">

--- a/wagtail_footnotes/wagtail_hooks.py
+++ b/wagtail_footnotes/wagtail_hooks.py
@@ -25,6 +25,7 @@ def register_footnotes_feature(features):
         draftail_features.EntityFeature(
             control,
             js=["wagtailadmin/js/draftail.js", "footnotes/js/footnotes.js"],
+            css={"all": ["footnotes/css/footnotes-admin.css"]},
         ),
     )
 


### PR DESCRIPTION
:warning: Based on #90 because we now have multiple footnotes :warning: 

> [!IMPORTANT]
> A good 90% of the JS here is written by Claude :robot: It needs reviewing CAREFULLY

This PR addresses UX improvements suggested on https://github.com/torchbox/wagtail-footnotes/issues/78

<div>
    <a href="https://www.loom.com/share/95112c2826fb4d69b16b75bee261a37c">
      <p>Wagtail footnotes UX improvements - 21 April 2026 - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/95112c2826fb4d69b16b75bee261a37c">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/95112c2826fb4d69b16b75bee261a37c-649b0eaf9005e598-full-play.gif#t=0.1">
    </a>
  </div>

## Feature 1 "Create new footnote" button in the chooser modal

<img width="175" height="95" alt="Screenshot from 2026-04-21 13-41-41" src="https://github.com/user-attachments/assets/7a58ad3c-ead8-411b-a41f-5a69ff52c348" />

Previously the modal told the user to close it, scroll down to the Footnotes panel, add a row, then reopen the modal, a confusing round-trip. There is now a "Create new footnote" button that:
  - Generates a UUID upfront and immediately inserts a [shortid] entity into the rich text at the
  cursor
  - Closes the modal, clicks the inline panel's Add button, and uses a MutationObserver to detect
  the new form row
  - Stamps the pre-generated UUID onto the new row's hidden input so the entity and the panel row
  are in sync
  - Scrolls to the new row and focuses its Draftail editor

 The old "close this window and scroll to Footnotes" instruction has been removed. The modal's data-controller="w-tabs" attribute has also been removed, it was causing a Stimulus console error because no role="tablist" child was present.

## Feature 2: Click [fn] in editor → scroll to footnote panel

Each in-text footnote reference in the Draftail editor is now styled as a link (underlined, Wagtail link colour) and clickable. Clicking scrolls the page to the corresponding inline panel row.

## Feature 3: "↑ Go to reference" in each footnote panel row

<img width="384" height="334" alt="Screenshot from 2026-04-21 13-42-20" src="https://github.com/user-attachments/assets/33221d12-f9fa-4f42-bec8-bb6230eb05ce" />

Each footnote panel row gets a back-link injected just below its short ID. If the footnote is referenced more than once, numbered links are shown (↑ Go to reference: 1 2 3) each scrolling to  the corresponding in-text occurrence.

## Test plan

- Create a page with a rich text block, open the footnote chooser, click "Create new footnote"...  confirm a [shortid] appears in the editor, the modal closes, a new footnote panel row is added,  and the page scrolls to that row with focus in the text editor
- Click an existing [fn] reference in the Draftail editor — confirm the page scrolls to the matching footnote panel row
- Check that footnote panel rows show "↑ Go to reference" (single ref) or numbered links (multiple refs), and that each link scrolls to the correct in-text occurrence
- Publish a page with the same footnote referenced twice — confirm both footnote-source-1-1 and footnote-source-1-2 anchors are present and the back-links in the footnote list are correct
 - Run the test suite: python -m django test tests --settings=tests.settings

###  Notes

- JS behaviour for Features 2 & 3 (scroll/click/MutationObserver) has no automated test coverage, this project has no JS test infrastructure. Worth a follow-up to introduce something?