### PR TITLE
Wagtail 74 maintenance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,13 +19,13 @@ repos:
     - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Keep in sync with .github/workflows/ruff.yml
-    rev: 'v0.15.10'
+    rev: 'v0.15.12'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/jackdewinter/pymarkdown
-    rev: v0.9.36
+    rev: v0.9.37
     hooks:
         - id: pymarkdown
           args:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Drop support for Wagtail 6.3 (EOL May 2026) and Wagtail 7.2 (EOL May 2026)
+- Add support for Wagtail 7.4 LTS
+- Update tox matrix to test Wagtail 7.0, 7.3, and 7.4
+
 ## 0.15.0
 
 - Add support for multiple references to the same footnote (https://github.com/torchbox/wagtail-footnotes/pull/90) @jsma

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,14 +27,13 @@ classifiers = [
     "Framework :: Django :: 5.2",
     "Framework :: Django :: 6.0",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 6",
     "Framework :: Wagtail :: 7",
 ]
 
 dynamic = ["version"]  # will read __version__ from wagtail_footnotes/__init__.py
 requires-python = ">=3.10"
 dependencies = [
-    "Wagtail>=6.3",
+    "Wagtail>=7.0",
     "Django>=4.2",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,9 @@ dependencies = [
 
 [project.optional-dependencies]
 testing = [
-    "pre-commit>=4.5",
-    "tox>=4.36,<5",
-    "coverage>=7.12,<8.0",
+    "pre-commit>=4.6",
+    "tox>=4.53,<5",
+    "coverage>=7.14,<8.0",
     "wagtail-modeladmin>=2.2.0",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,9 @@ min_version = 4.32
 skipmissing_interpreters = true
 
 envlist =
-    python{3.10,3.11}-django4.2-wagtail{6.3,7.0}
-    python{3.12,3.13}-django5.2-wagtail{7.2,7.3}
-    python3.14-django{5.2,6.0}-wagtail7.3
+    python{3.10,3.11}-django4.2-wagtail7.0
+    python{3.12,3.13}-django5.2-wagtail{7.0,7.3,7.4}
+    python3.14-django{5.2,6.0}-wagtail{7.3,7.4}
 
 [gh-actions]
 python =
@@ -36,10 +36,9 @@ deps =
     django5.2: Django>=5.2,<5.3
     django6.0: Django>=6.0,<6.1
 
-    wagtail6.3: wagtail>=6.3,<6.4
     wagtail7.0: wagtail>=7.0,<7.1
-    wagtail7.2: wagtail>=7.2,<7.3
     wagtail7.3: wagtail>=7.3,<7.4
+    wagtail7.4: wagtail>=7.4,<7.5
 
 
 extras = testing


### PR DESCRIPTION
## Summary

  Refresh the supported version matrix following Wagtail's May 2026 release cadence.

  - Wagtail 6.3 LTS reached EOL on 1 May 2026
  - Wagtail 7.2 reached EOL on 4 May 2026
  - Wagtail 7.4 LTS released on 4 May 2026 (Django 5.2/6.0, Python 3.10–3.14)

  ## Changes

  **Production**
  - Raise minimum Wagtail to `>=7.0` (was `>=6.3`)
  - Drop `Framework :: Wagtail :: 6` classifier
  - Update tox envlist: remove `wagtail6.3` and `wagtail7.2`, add `wagtail7.4`
  - New matrix:
    - `py{3.10,3.11}-django4.2-wagtail7.0`
    - `py{3.12,3.13}-django5.2-wagtail{7.0,7.3,7.4}`
    - `py3.14-django{5.2,6.0}-wagtail{7.3,7.4}`
  - CHANGELOG entry under Unreleased

  **Dev tooling** (separate commit)
  - `pre-commit>=4.6`, `tox>=4.53,<5`, `coverage>=7.14,<8.0`
  - ruff pre-commit hook `v0.15.10` → `v0.15.12`
  - pymarkdown pre-commit hook `v0.9.36` → `v0.9.37`

  ## Support policy

  | | Supported |
  |---|---|
  | Python | 3.10, 3.11, 3.12, 3.13, 3.14 |
  | Django | 4.2, 5.2, 6.0 |
  | Wagtail | 7.0 LTS, 7.3, 7.4 LTS |

  Django 4.2 is retained because Wagtail 7.0 LTS (still in the support window) requires it.